### PR TITLE
Implement configurable date format for carbon interpreter

### DIFF
--- a/src/DataDefinitionsBundle/Form/Type/Interpreter/CarbonInterpreterType.php
+++ b/src/DataDefinitionsBundle/Form/Type/Interpreter/CarbonInterpreterType.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Import Definitions.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2016-2018 w-vision AG (https://www.w-vision.ch)
+ * @license    https://github.com/w-vision/ImportDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ */
+
+namespace Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class CarbonInterpreterType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('date_format', TextType::class)
+        ;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'import_definitions_interpreter_carbon';
+    }
+}

--- a/src/DataDefinitionsBundle/Interpreter/CarbonInterpreter.php
+++ b/src/DataDefinitionsBundle/Interpreter/CarbonInterpreter.php
@@ -31,6 +31,11 @@ class CarbonInterpreter implements InterpreterInterface, DataSetAwareInterface
     public function interpret(Concrete $object, $value, Mapping $map, $data, DefinitionInterface $definition, $params, $configuration)
     {
         if ($value) {
+            $format = $configuration['date_format'];
+            if (!empty($format)) {
+                return Carbon::createFromFormat($format, $value);
+            }
+
             return new Carbon($value);
         }
 

--- a/src/DataDefinitionsBundle/Resources/config/pimcore/config.yml
+++ b/src/DataDefinitionsBundle/Resources/config/pimcore/config.yml
@@ -51,6 +51,7 @@ import_definitions:
             interpreter_definition: '/bundles/datadefinitions/pimcore/js/interpreters/definition.js'
             interpreter_conditional: '/bundles/datadefinitions/pimcore/js/interpreters/conditional.js'
             interpreter_twig: '/bundles/datadefinitions/pimcore/js/interpreters/twig.js'
+            interpreter_carbon: '/bundles/datadefinitions/pimcore/js/interpreters/carbon.js'
             setter_abstract: '/bundles/datadefinitions/pimcore/js/setters/abstract.js'
             setter_fieldcollection: '/bundles/datadefinitions/pimcore/js/setters/fieldcollection.js'
             setter_objectbrick: '/bundles/datadefinitions/pimcore/js/setters/objectbrick.js'

--- a/src/DataDefinitionsBundle/Resources/config/services.yml
+++ b/src/DataDefinitionsBundle/Resources/config/services.yml
@@ -195,7 +195,7 @@ services:
     import_definition.interpreter.carbon: '@Wvision\Bundle\DataDefinitionsBundle\Interpreter\CarbonInterpreter'
     Wvision\Bundle\DataDefinitionsBundle\Interpreter\CarbonInterpreter:
         tags:
-            - { name: data_definitions.interpreter, type: carbon, form-type: Wvision\Bundle\DataDefinitionsBundle\Form\Type\NoConfigurationType }
+            - { name: data_definitions.interpreter, type: carbon, form-type: Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter\CarbonInterpreterType }
 
     import_definition.interpreter.checkbox: '@Wvision\Bundle\DataDefinitionsBundle\Interpreter\CheckboxInterpreter'
     Wvision\Bundle\DataDefinitionsBundle\Interpreter\CheckboxInterpreter:

--- a/src/DataDefinitionsBundle/Resources/public/pimcore/js/interpreters/carbon.js
+++ b/src/DataDefinitionsBundle/Resources/public/pimcore/js/interpreters/carbon.js
@@ -1,0 +1,26 @@
+/**
+ * Import Definitions.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2016-2018 w-vision AG (https://www.w-vision.ch)
+ * @license    https://github.com/w-vision/ImportDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ */
+
+pimcore.registerNS('pimcore.plugin.datadefinitions.interpreters.carbon');
+
+pimcore.plugin.datadefinitions.interpreters.carbon = Class.create(pimcore.plugin.datadefinitions.interpreters.abstract, {
+    getLayout : function (fromColumn, toColumn, record, config) {
+        return [{
+            xtype : 'textfield',
+            fieldLabel: t('date_format'),
+            name: 'date_format',
+            width: 500,
+            value : config.date_format ? config.date_format : null
+        }];
+    }
+});


### PR DESCRIPTION

Q | A
-- | --
Bug fix? | no
New feature? | yes
BC breaks? | no
Deprecations? | no

Add possibility to define a custom date format in the Carbon interpreter, so we can use arbitrary dates while importing.
