### PR TITLE
Allow consumers of the importer to set a filter instance Definition

### DIFF
--- a/src/DataDefinitionsBundle/Filter/FilterInterface.php
+++ b/src/DataDefinitionsBundle/Filter/FilterInterface.php
@@ -24,9 +24,10 @@ interface FilterInterface
      * @param array $data
      * @param Concrete $object
      *
+     * @param array $configuration
      * @return boolean
      */
-    public function filter(DefinitionInterface $definition, $data, $object);
+    public function filter(DefinitionInterface $definition, $data, $object, array $configuration);
 }
 
 class_alias(FilterInterface::class, 'ImportDefinitionsBundle\Filter\FilterInterface');

--- a/src/DataDefinitionsBundle/Filter/NestedFilter.php
+++ b/src/DataDefinitionsBundle/Filter/NestedFilter.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Data Definitions.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2016-2019 w-vision AG (https://www.w-vision.ch)
+ * @license    https://github.com/w-vision/ImportDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ */
+
+namespace Wvision\Bundle\DataDefinitionsBundle\Filter;
+
+use CoreShop\Component\Registry\ServiceRegistryInterface;
+use Wvision\Bundle\DataDefinitionsBundle\Model\DefinitionInterface;
+use Webmozart\Assert\Assert;
+
+final class NestedFilter implements FilterInterface
+{
+    /**
+     * @var ServiceRegistryInterface
+     */
+    private $filterRegistry;
+
+    /**
+     * @param ServiceRegistryInterface $filterRegistry
+     */
+    public function __construct(ServiceRegistryInterface $filterRegistry)
+    {
+        $this->filterRegistry = $filterRegistry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function filter(DefinitionInterface $definition, $data, $object, array $configuration)
+    {
+        Assert::keyExists($configuration, 'filters');
+        Assert::isArray($configuration['filters'], 'Filter Config needs to be array');
+
+        foreach ($configuration['filters'] as $filter) {
+            /** @var FilterInterface $filter */
+            $filter = $this->filterRegistry->get($filter['type']);
+            if (!$filter->filter($definition, $data, $object)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/DataDefinitionsBundle/Importer/Importer.php
+++ b/src/DataDefinitionsBundle/Importer/Importer.php
@@ -145,9 +145,7 @@ final class Importer implements ImporterInterface
         }
 
         $filterType = $definition->getFilter();
-        if ($filterType instanceof FilterInterface) {
-            $filter = $filterType;
-        } else {
+        if ($filterType) {
             $filter = $this->filterRegistry->get($filterType);
         }
 

--- a/src/DataDefinitionsBundle/Importer/Importer.php
+++ b/src/DataDefinitionsBundle/Importer/Importer.php
@@ -145,7 +145,9 @@ final class Importer implements ImporterInterface
         }
 
         $filterType = $definition->getFilter();
-        if ($filterType) {
+        if ($filterType instanceof FilterInterface) {
+            $filter = $filterType;
+        } else {
             $filter = $this->filterRegistry->get($filterType);
         }
 

--- a/src/DataDefinitionsBundle/Resources/config/pimcore/config.yml
+++ b/src/DataDefinitionsBundle/Resources/config/pimcore/config.yml
@@ -63,6 +63,8 @@ import_definitions:
             getter_localizedfield: '/bundles/datadefinitions/pimcore/js/getters/localizedfield.js'
             fetcher_abstract: '/bundles/datadefinitions/pimcore/js/fetchers/abstract.js'
             fetcher_objects: '/bundles/datadefinitions/pimcore/js/fetchers/objects.js'
+            filter_abstract: '/bundles/datadefinitions/pimcore/js/filters/abstract.js'
+            filter_nested: '/bundles/datadefinitions/pimcore/js/filters/nested.js'
             fuse: '/bundles/datadefinitions/pimcore/js/automap/fuse.min.js'
         css:
             data_definition: '/bundles/datadefinitions/pimcore/css/datadefinition.css'

--- a/src/DataDefinitionsBundle/Resources/config/services.yml
+++ b/src/DataDefinitionsBundle/Resources/config/services.yml
@@ -381,3 +381,9 @@ services:
     Wvision\Bundle\DataDefinitionsBundle\Loader\PrimaryKeyLoader:
         tags:
             - { name: data_definitions.loader, type: primary_key }
+
+    ### FILTER
+    import_definition.filter.nested: '@Wvision\Bundle\DataDefinitionsBundle\Filter\NestedFilter'
+    Wvision\Bundle\DataDefinitionsBundle\Filter\NestedFilter:
+        tags:
+            - { name: data_definitions.filter, type: nested }

--- a/src/DataDefinitionsBundle/Resources/public/pimcore/js/filters/abstract.js
+++ b/src/DataDefinitionsBundle/Resources/public/pimcore/js/filters/abstract.js
@@ -1,0 +1,21 @@
+/**
+ * Data Definitions.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2016-2019 w-vision AG (https://www.w-vision.ch)
+ * @license    https://github.com/w-vision/ImportDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ */
+
+pimcore.registerNS('pimcore.plugin.datadefinitions.filters');
+pimcore.registerNS('pimcore.plugin.datadefinitions.filters.abstract');
+
+pimcore.plugin.datadefinitions.filters.abstract = Class.create({
+    getLayout : function () {
+        return [];
+    }
+});

--- a/src/DataDefinitionsBundle/Resources/public/pimcore/js/filters/nested.js
+++ b/src/DataDefinitionsBundle/Resources/public/pimcore/js/filters/nested.js
@@ -1,0 +1,119 @@
+/**
+ * Data Definitions.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2016-2019 w-vision AG (https://www.w-vision.ch)
+ * @license    https://github.com/w-vision/ImportDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ */
+
+pimcore.registerNS('pimcore.plugin.datadefinitions.filters.nested');
+
+pimcore.plugin.datadefinitions.filters.nested = Class.create(pimcore.plugin.datadefinitions.filters.abstract, {
+    getStore: function() {
+        return pimcore.globalmanager.get('data_definitions_filters');
+    },
+
+    getClassItem: function() {
+        return pimcore.plugin.datadefinitions.filters;
+    },
+
+    getFilterIdentifier: function(filter) {
+        return filter.get('filter');
+    },
+
+    getLayout: function (config) {
+        // init
+        var _this = this;
+        var addMenu = [];
+
+        this.getStore().clearFilter();
+
+        var records = this.getStore().getRange().map(function(filter) {return _this.getFilterIdentifier(filter);});
+
+        Ext.each(records, function (filter) {
+            if (filter === 'abstract')
+                return;
+
+            addMenu.push({
+                text: filter,
+                handler: _this.addFilter.bind(_this, filter, {})
+            });
+
+        });
+
+        this.filterContainer = new Ext.Panel({
+            autoScroll: true,
+            forceLayout: true,
+            tbar: [{
+                iconCls: 'pimcore_icon_add',
+                menu: addMenu
+            }],
+            border: false
+        });
+
+        if (config && config.filters) {
+            Ext.each(config.filters, function (filter) {
+                this.addFilter(filter.type, filter.filterConfig);
+            }.bind(this));
+        }
+
+        return this.filterContainer;
+    },
+
+    destroy: function () {
+        if (this.filterContainer) {
+            this.filterContainer.destroy();
+        }
+    },
+
+    getFilterClassItem: function (type) {
+        var items = this.getClassItem();
+
+        if (Object.keys(items).indexOf(type) >= 0) {
+            return items[type];
+        }
+
+        return items.empty;
+    },
+
+    addFilter: function (type, config) {
+        var filterClass = this.getFilterClassItem(type);
+        var item = new filterClass();
+        var container = new pimcore.plugin.datadefinitions.filters.nestedcontainer(this, type, item);
+
+        this.filterContainer.add(container.getLayout(type, fromColumn, toColumn, record, config));
+        this.filterContainer.updateLayout();
+    },
+
+    getFilterData: function () {
+        // get defined conditions
+        var filterData = [];
+        var filters = this.filterContainer.items.getRange();
+        for (var i = 0; i < filters.length; i++) {
+            var configuration = {};
+            var filter = {};
+
+            var filterItem = filters[i];
+            var filterClass = filterItem.xparent;
+
+
+            if (Ext.isFunction(filterClass['getValues'])) {
+                configuration = filterClass.getValues();
+            }
+
+            filter['filterConfig'] = configuration;
+            filter['type'] = filters[i].xparent.type;
+
+            filterData.push(filter);
+        }
+
+        return {
+            filters: filterData
+        };
+    }
+});

--- a/src/DataDefinitionsBundle/Resources/public/pimcore/js/import/item.js
+++ b/src/DataDefinitionsBundle/Resources/public/pimcore/js/import/item.js
@@ -157,6 +157,11 @@ pimcore.plugin.datadefinitions.import.item = Class.create(pimcore.plugin.datadef
                     listeners: {
                         change: function (combo, value) {
                             this.data.filter = value;
+
+                            this.getFilterPanel().removeAll();
+
+                            this.getFilterPanelLayout(value);
+                            //@todo load configuration form
                         }.bind(this)
                     }
                 },
@@ -636,5 +641,46 @@ pimcore.plugin.datadefinitions.import.item = Class.create(pimcore.plugin.datadef
         }
 
         return data;
-    }
+    },
+
+    getFilterPanel : function () {
+        if (!this.filterPanel) {
+            this.filterPanel = new Ext.form.FormPanel({
+                defaults: { anchor: '90%' },
+                layout: 'form',
+                title : t('data_definitions_filter_settings')
+            });
+        }
+
+        return this.filterPanel;
+    },
+
+    getFilterPanelLayout : function (type) {
+        debugger;
+        if (type) {
+            type = type.toLowerCase();
+
+            var klass;
+
+            if (pimcore.plugin.importdefinitions && pimcore.plugin.importdefinitions.filters[type]) {
+                klass = pimcore.plugin.importdefinitions.filters[type];
+            }
+            else if (pimcore.plugin.datadefinitions.filters[type]) {
+                klass = pimcore.plugin.datadefinitions.filters[type];
+            }
+
+            if (klass) {
+                this.filter = new klass;
+
+                this.getFilterPanel().add(this.filter.getLayout(Ext.isObject(this.data.filterConfig) ? this.data.filterConfig : {}, this.config));
+                this.getFilterPanel().show();
+            } else {
+                this.getFilterPanel().hide();
+
+                this.filter = null;
+            }
+        } else {
+            this.getFilterPanel().hide();
+        }
+    },
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

In our project we have a number of import definitions which can be run. I want to apply a default filter for all definitions.

With the minor change in this PR I can do something like this in my application:

```
class ImporterWrapper implements ImporterInterface
{
    private $filterRegistry;

    private $defaultFilter;

    private $importer;

    public function __construct(ImporterInterface $importer, ServiceRegistryInterface $filterRegistry, FilterInterface $defaultFilter)
    {
        $this->filterRegistry = $filterRegistry;
        $this->defaultFilter = $defaultFilter;
        $this->importer = $importer;
    }

    public function doImport(DefinitionInterface $definition, $params)
    {
        $filterType = $definition->getFilter();
        $filter = $this->filterRegistry->get($filterType);
        $definition->setFilter(new AggregateFilter($filter, $this->defaultFilter));
        
        return $this->importer->doImport($definition, $params);
    }
}

class AggregateFilter implements FilterInterface
{
    protected $filters = [];
    
    public function __construct(...$filters)
    {
        $this->filters = $filters;
    }
    
    public function filter(DefinitionInterface $definition, $data, $object)
    {
        foreach ($this->filters as $filter) {
            if (!$filter->filter($definition, $data, $object)) {
                return false;
            }
        }
        return true;
    }
}
```
