### PR TITLE
fix / Show errors in report

### DIFF
--- a/src/DataDefinitionsBundle/ProcessManager/ImportDefinitionsReport.php
+++ b/src/DataDefinitionsBundle/ProcessManager/ImportDefinitionsReport.php
@@ -198,7 +198,7 @@ class ImportDefinitionsReport implements ReportInterface
     {
         $pos = strpos($line, self::EVENT_STATUS_ERROR);
         if (false !== $pos) {
-            $result[$result['currentObject']]['error'] = substr($line, $pos + strlen(self::EVENT_STATUS_ERROR));
+            $result['productStatus'][$result['currentObject']]['error'] = substr($line, $pos + strlen(self::EVENT_STATUS_ERROR));
 
             return true;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Information about an error is saved in array but not in `productStatus` key. Because of that in the report, we don't have information about errors.