### PR TITLE
[Interpreter] Added CoreShop Money interpreter

### DIFF
--- a/src/DataDefinitionsBundle/DependencyInjection/DataDefinitionsExtension.php
+++ b/src/DataDefinitionsBundle/DependencyInjection/DataDefinitionsExtension.php
@@ -58,7 +58,7 @@ class DataDefinitionsExtension extends AbstractModelExtension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
@@ -77,6 +77,7 @@ class DataDefinitionsExtension extends AbstractModelExtension
         if (array_key_exists('CoreShopCoreBundle', $bundles)) {
             $config['pimcore_admin']['js']['coreshop_interpreter_price'] = '/bundles/datadefinitions/pimcore/js/coreshop/interpreter/price.js';
             $config['pimcore_admin']['js']['coreshop_interpreter_stores'] = '/bundles/datadefinitions/pimcore/js/coreshop/interpreter/stores.js';
+            $config['pimcore_admin']['js']['coreshop_interpreter_money'] = '/bundles/datadefinitions/pimcore/js/coreshop/interpreter/money.js';
             $config['pimcore_admin']['js']['coreshop_setter_storePrice'] = '/bundles/datadefinitions/pimcore/js/coreshop/setter/storePrice.js';
             $config['pimcore_admin']['js']['coreshop_getter_storePrice'] = '/bundles/datadefinitions/pimcore/js/coreshop/getter/storePrice.js';
             $config['pimcore_admin']['js']['coreshop_setter_store_values'] = '/bundles/datadefinitions/pimcore/js/coreshop/setter/storeValues.js';

--- a/src/DataDefinitionsBundle/Form/Type/Interpreter/CoreShop/MoneyInterpreterType.php
+++ b/src/DataDefinitionsBundle/Form/Type/Interpreter/CoreShop/MoneyInterpreterType.php
@@ -4,9 +4,9 @@
 namespace Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter\CoreShop;
 
 
+use CoreShop\Bundle\CurrencyBundle\Form\Type\CurrencyChoiceType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
-use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 final class MoneyInterpreterType extends AbstractType
@@ -18,6 +18,6 @@ final class MoneyInterpreterType extends AbstractType
     {
         $builder
             ->add('isFloat', CheckboxType::class)
-            ->add('currency', IntegerType::class);
+            ->add('currency', CurrencyChoiceType::class);
     }
 }

--- a/src/DataDefinitionsBundle/Form/Type/Interpreter/CoreShop/MoneyInterpreterType.php
+++ b/src/DataDefinitionsBundle/Form/Type/Interpreter/CoreShop/MoneyInterpreterType.php
@@ -4,9 +4,9 @@
 namespace Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter\CoreShop;
 
 
-use CoreShop\Bundle\CurrencyBundle\Form\Type\CurrencyChoiceType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 final class MoneyInterpreterType extends AbstractType
@@ -18,6 +18,6 @@ final class MoneyInterpreterType extends AbstractType
     {
         $builder
             ->add('isFloat', CheckboxType::class)
-            ->add('currency', CurrencyChoiceType::class);
+            ->add('currency', IntegerType::class);
     }
 }

--- a/src/DataDefinitionsBundle/Form/Type/Interpreter/CoreShop/MoneyInterpreterType.php
+++ b/src/DataDefinitionsBundle/Form/Type/Interpreter/CoreShop/MoneyInterpreterType.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter\CoreShop;
+
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class MoneyInterpreterType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('isFloat', CheckboxType::class)
+            ->add('currency', IntegerType::class);
+    }
+}

--- a/src/DataDefinitionsBundle/Form/Type/Interpreter/CoreShop/MoneyInterpreterType.php
+++ b/src/DataDefinitionsBundle/Form/Type/Interpreter/CoreShop/MoneyInterpreterType.php
@@ -4,9 +4,11 @@
 namespace Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter\CoreShop;
 
 
+use CoreShop\Bundle\CurrencyBundle\Form\Type\CurrencyChoiceType;
+use CoreShop\Component\Currency\Model\CurrencyInterface;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
-use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 final class MoneyInterpreterType extends AbstractType
@@ -18,6 +20,19 @@ final class MoneyInterpreterType extends AbstractType
     {
         $builder
             ->add('isFloat', CheckboxType::class)
-            ->add('currency', IntegerType::class);
+            ->add('currency', CurrencyChoiceType::class)
+            ->addModelTransformer(new CallbackTransformer(
+                function ($value) {
+                    return $value;
+                },
+                function ($value) {
+
+                    if (isset($value['currency']) && $value['currency'] instanceof CurrencyInterface) {
+                        $value['currency'] = $value['currency']->getId();
+                    }
+
+                    return $value;
+                }
+            ));
     }
 }

--- a/src/DataDefinitionsBundle/Interpreter/CoreShop/MoneyInterpreter.php
+++ b/src/DataDefinitionsBundle/Interpreter/CoreShop/MoneyInterpreter.php
@@ -8,9 +8,7 @@ use CoreShop\Component\Core\Repository\CurrencyRepositoryInterface;
 use CoreShop\Component\Currency\Model\CurrencyInterface;
 use CoreShop\Component\Currency\Model\Money;
 use Pimcore\Model\DataObject\Concrete;
-use Wvision\Bundle\DataDefinitionsBundle\Exception\DoNotSetException;
 use Wvision\Bundle\DataDefinitionsBundle\Interpreter\InterpreterInterface;
-use Wvision\Bundle\DataDefinitionsBundle\Interpreter\Mapping;
 use Wvision\Bundle\DataDefinitionsBundle\Model\DataDefinitionInterface;
 use Wvision\Bundle\DataDefinitionsBundle\Model\MappingInterface;
 
@@ -59,6 +57,7 @@ final class MoneyInterpreter implements InterpreterInterface
     private function getValue($value, $configuration)
     {
         $inputIsFloat = $configuration['isFloat'];
+
         $value = preg_replace("/[^0-9,.]+/", "", $value);
 
         if (\is_string($value)) {

--- a/src/DataDefinitionsBundle/Interpreter/CoreShop/MoneyInterpreter.php
+++ b/src/DataDefinitionsBundle/Interpreter/CoreShop/MoneyInterpreter.php
@@ -1,0 +1,98 @@
+<?php
+
+
+namespace Wvision\Bundle\DataDefinitionsBundle\Interpreter\CoreShop;
+
+
+use CoreShop\Component\Core\Repository\CurrencyRepositoryInterface;
+use CoreShop\Component\Currency\Model\CurrencyInterface;
+use CoreShop\Component\Currency\Model\Money;
+use Pimcore\Model\DataObject\Concrete;
+use Wvision\Bundle\DataDefinitionsBundle\Exception\DoNotSetException;
+use Wvision\Bundle\DataDefinitionsBundle\Interpreter\InterpreterInterface;
+use Wvision\Bundle\DataDefinitionsBundle\Interpreter\Mapping;
+use Wvision\Bundle\DataDefinitionsBundle\Model\DataDefinitionInterface;
+use Wvision\Bundle\DataDefinitionsBundle\Model\MappingInterface;
+
+final class MoneyInterpreter implements InterpreterInterface
+{
+
+    /**
+     * @var CurrencyRepositoryInterface
+     */
+    private $currencyRepository;
+
+    public function __construct(CurrencyRepositoryInterface $currencyRepository)
+    {
+        $this->currencyRepository = $currencyRepository;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function interpret(
+        Concrete $object,
+        $value,
+        MappingInterface $map,
+        $data,
+        DataDefinitionInterface $definition,
+        $params,
+        $configuration
+    )
+    {
+        $value = $this->getValue($value, $configuration);
+        $currency = $this->resolveCurrency($value, $configuration);
+
+        if (null === $currency) {
+            return null;
+        }
+
+        return new Money($value, $currency);
+    }
+
+    /**
+     * @param $value
+     * @param $configuration
+     *
+     * @return int
+     */
+    private function getValue($value, $configuration)
+    {
+        $inputIsFloat = $configuration['isFloat'];
+        $value = preg_replace("/[^0-9,.]+/", "", $value);
+
+        if (\is_string($value)) {
+            $value = str_replace(',', '.', $value);
+            $value = (float)$value;
+        }
+
+        if ($inputIsFloat) {
+            $value = (int)round(round($value, 2) * 100, 0);
+        }
+
+        return (int)$value;
+    }
+
+    /**
+     * @param string $value
+     * @param array $configuration
+     *
+     * @return CurrencyInterface|null
+     */
+    private function resolveCurrency($value, $configuration)
+    {
+        if (preg_match('/^\pL+$/u', $value)) {
+
+            // data contains letters
+            $currencyCode = preg_replace("/[^a-zA-Z]+/", "", $value);
+
+            return $this->currencyRepository->getByCode($currencyCode);
+        }
+
+        if (isset($configuration['currency']) && null !== $configuration['currency']) {
+            return $this->currencyRepository->find($configuration['currency']);
+        }
+
+        return null;
+    }
+}

--- a/src/DataDefinitionsBundle/Interpreter/CoreShop/MoneyInterpreter.php
+++ b/src/DataDefinitionsBundle/Interpreter/CoreShop/MoneyInterpreter.php
@@ -81,18 +81,18 @@ final class MoneyInterpreter implements InterpreterInterface
      */
     private function resolveCurrency($value, $configuration)
     {
-        if (preg_match('/^\pL+$/u', $value)) {
+        $currency = null;
 
-            // data contains letters
+        if (preg_match('/^\pL+$/u', $value)) {
             $currencyCode = preg_replace("/[^a-zA-Z]+/", "", $value);
 
-            return $this->currencyRepository->getByCode($currencyCode);
+            $currency = $this->currencyRepository->getByCode($currencyCode);
         }
 
-        if (isset($configuration['currency']) && null !== $configuration['currency']) {
-            return $this->currencyRepository->find($configuration['currency']);
+        if ($currency === null && isset($configuration['currency']) && null !== $configuration['currency']) {
+            $currency = $this->currencyRepository->find($configuration['currency']);
         }
 
-        return null;
+        return $currency;
     }
 }

--- a/src/DataDefinitionsBundle/Resources/config/coreshop.yml
+++ b/src/DataDefinitionsBundle/Resources/config/coreshop.yml
@@ -28,3 +28,9 @@ services:
             - '@coreshop.repository.currency'
         tags:
             - { name: data_definitions.interpreter, type: coreshop_currency, form-type: Wvision\Bundle\DataDefinitionsBundle\Form\Type\NoConfigurationType }
+
+    Wvision\Bundle\DataDefinitionsBundle\Interpreter\CoreShop\MoneyInterpreter:
+        arguments:
+            - '@coreshop.repository.currency'
+        tags:
+            - { name: data_definitions.interpreter, type: coreshop_money, form-type: Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter\CoreShop\MoneyInterpreterType }

--- a/src/DataDefinitionsBundle/Resources/public/pimcore/js/coreshop/interpreter/money.js
+++ b/src/DataDefinitionsBundle/Resources/public/pimcore/js/coreshop/interpreter/money.js
@@ -1,0 +1,21 @@
+pimcore.registerNS('pimcore.plugin.datadefinitions.interpreters.coreshop_money');
+
+pimcore.plugin.datadefinitions.interpreters.coreshop_money = Class.create(pimcore.plugin.datadefinitions.interpreters.abstract, {
+    getLayout: function (fromColumn, toColumn, record, config) {
+        return [
+            {
+                xtype: 'checkbox',
+                fieldLabel: t('data_definitions_interpreter_coreshop_is_float'),
+                name: 'isFloat',
+                value: config.isFloat ? config.isFloat : false
+            },
+            {
+                xtype: 'coreshop.currency',
+                name: 'currency',
+                multiSelect: false,
+                typeAhead: false,
+                value: config.currency
+            }
+        ];
+    }
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

If a currency code is in the import value, the currency object is searched for via the repository. If no currency is found, the currency of the configuration is returned.
