### PR TITLE
CsvProvider's getData can return iterator

### DIFF
--- a/src/DataDefinitionsBundle/Provider/CsvProvider.php
+++ b/src/DataDefinitionsBundle/Provider/CsvProvider.php
@@ -125,7 +125,7 @@ class CsvProvider extends AbstractFileProvider implements ImportProviderInterfac
 
         $records = $stmt->process($csv);
 
-        return iterator_to_array($records);
+        return $records;
     }
 
     /**


### PR DESCRIPTION
As importing supports iterators, there is no point in returning array here.
For tested 70MB CSV file this lowers the memory consumption at import start from >1GB to 40MB

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no