### PR TITLE
Using Pimcore's HttpClient to download data

### DIFF
--- a/src/DataDefinitionsBundle/Interpreter/AssetUrlInterpreter.php
+++ b/src/DataDefinitionsBundle/Interpreter/AssetUrlInterpreter.php
@@ -17,7 +17,6 @@ namespace Wvision\Bundle\DataDefinitionsBundle\Interpreter;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\TransferException;
 use Pimcore\File;
-use Pimcore\Http\ClientFactory;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Tool as PimcoreTool;
@@ -40,11 +39,18 @@ class AssetUrlInterpreter implements InterpreterInterface, DataSetAwareInterface
     protected $placeholderService;
 
     /**
-     * @param Placeholder $placeholderService
+     * @var Client
      */
-    public function __construct(Placeholder $placeholderService)
+    protected $httpClient;
+
+    /**
+     * @param Placeholder $placeholderService
+     * @param Client $httpClient
+     */
+    public function __construct(Placeholder $placeholderService, Client $httpClient)
     {
         $this->placeholderService = $placeholderService;
+        $this->httpClient = $httpClient;
     }
 
     /**
@@ -139,10 +145,8 @@ class AssetUrlInterpreter implements InterpreterInterface, DataSetAwareInterface
      */
     protected function getFileContents(string $value): ?string
     {
-        $httpClient = $this->createHttpClient();
-
         try {
-            $response = $httpClient->request('GET', $value);
+            $response = $this->httpClient->request('GET', $value);
         } catch (TransferException $ex) {
             $response = null;
         }
@@ -153,18 +157,4 @@ class AssetUrlInterpreter implements InterpreterInterface, DataSetAwareInterface
 
         return null;
     }
-
-    /**
-     * @param array $config
-     * @return Client
-     */
-    protected function createHttpClient(array $config = []): Client
-    {
-        /** @var ClientFactory $clientFactory */
-        $clientFactory = \Pimcore::getContainer()->get(ClientFactory::class);
-
-        return $clientFactory->createClient($config);
-    }
 }
-
-

--- a/src/DataDefinitionsBundle/Resources/config/services.yml
+++ b/src/DataDefinitionsBundle/Resources/config/services.yml
@@ -148,12 +148,14 @@ services:
     Wvision\Bundle\DataDefinitionsBundle\Interpreter\AssetsUrlInterpreter:
         arguments:
             - '@Wvision\Bundle\DataDefinitionsBundle\Service\Placeholder'
+            - '@GuzzleHttp\Client'
         tags:
             - { name: data_definitions.interpreter, type: assets_url, form-type: Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter\AssetsUrlInterpreterType }
 
     Wvision\Bundle\DataDefinitionsBundle\Interpreter\AssetUrlInterpreter:
         arguments:
             - '@Wvision\Bundle\DataDefinitionsBundle\Service\Placeholder'
+            - '@GuzzleHttp\Client'
         tags:
             - { name: data_definitions.interpreter, type: asset_url, form-type: Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter\AssetUrlInterpreterType }
 

--- a/src/DataDefinitionsBundle/Resources/config/services.yml
+++ b/src/DataDefinitionsBundle/Resources/config/services.yml
@@ -148,14 +148,14 @@ services:
     Wvision\Bundle\DataDefinitionsBundle\Interpreter\AssetsUrlInterpreter:
         arguments:
             - '@Wvision\Bundle\DataDefinitionsBundle\Service\Placeholder'
-            - '@GuzzleHttp\Client'
+            - '@pimcore.http_client'
         tags:
             - { name: data_definitions.interpreter, type: assets_url, form-type: Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter\AssetsUrlInterpreterType }
 
     Wvision\Bundle\DataDefinitionsBundle\Interpreter\AssetUrlInterpreter:
         arguments:
             - '@Wvision\Bundle\DataDefinitionsBundle\Service\Placeholder'
-            - '@GuzzleHttp\Client'
+            - '@pimcore.http_client'
         tags:
             - { name: data_definitions.interpreter, type: asset_url, form-type: Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter\AssetUrlInterpreterType }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #224 

AssetUrl Interpreter uses file_get_contents to download file. If Pimcore instance is using proxy to communicate with the Internet - it won't work.
Fix: use Pimcore's HttpClient to download data.
