### PR TITLE
KeySetter bugfix and Advanced Relations interpreter/setter

### DIFF
--- a/src/DataDefinitionsBundle/Form/Type/Interpreter/MetadataInterpreterType.php
+++ b/src/DataDefinitionsBundle/Form/Type/Interpreter/MetadataInterpreterType.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Data Definitions.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2016-2019 w-vision AG (https://www.w-vision.ch)
+ * @license    https://github.com/w-vision/DataDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ */
+
+namespace Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class MetadataInterpreterType extends AbstractType
+{
+    /**
+     * @param FormBuilderInterface $builder
+     * @param array                $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('class', TextType::class)
+            ->add('metadata', TextType::class);
+    }
+}
+
+

--- a/src/DataDefinitionsBundle/Interpreter/MetadataInterpreter.php
+++ b/src/DataDefinitionsBundle/Interpreter/MetadataInterpreter.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Data Definitions.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2016-2019 w-vision AG (https://www.w-vision.ch)
+ * @license    https://github.com/w-vision/DataDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ */
+
+namespace Wvision\Bundle\DataDefinitionsBundle\Interpreter;
+
+use Pimcore\Model\DataObject\Concrete;
+use Wvision\Bundle\DataDefinitionsBundle\Model\DataDefinitionInterface;
+use Wvision\Bundle\DataDefinitionsBundle\Model\MappingInterface;
+use Pimcore\Model\DataObject\Data\ElementMetadata;
+use Pimcore\Model\DataObject\Data\ObjectMetadata;
+
+class MetadataInterpreter implements InterpreterInterface
+{    
+    /**
+     * {@inheritdoc}
+     */
+    public function interpret(
+        Concrete $object,
+        $value,
+        MappingInterface $map,
+        $data,
+        DataDefinitionInterface $definition,
+        $params,
+        $configuration
+    ) {
+        $class = "\\Pimcore\\Model\\DataObject\\Data\\" . $configuration['class'];
+        $fieldname = $map->getToColumn();
+        
+        $metadata = $configuration['metadata'];
+        $metadata = json_decode($metadata, true);
+        if (!is_array($metadata)) {
+            $metadata = [];
+        }
+
+        $elementMetadata = new $class($fieldname, array_keys($metadata), $value);
+        foreach ($metadata as $metadataKey => $metadataValue) {
+            $setter = 'set' . ucfirst($metadataKey);
+            $elementMetadata->$setter($metadataValue);
+        }        
+        
+        return $elementMetadata;
+    }
+}
+
+

--- a/src/DataDefinitionsBundle/Resources/config/pimcore/config.yml
+++ b/src/DataDefinitionsBundle/Resources/config/pimcore/config.yml
@@ -52,6 +52,7 @@ data_definitions:
             interpreter_conditional: '/bundles/datadefinitions/pimcore/js/interpreters/conditional.js'
             interpreter_twig: '/bundles/datadefinitions/pimcore/js/interpreters/twig.js'
             interpreter_carbon: '/bundles/datadefinitions/pimcore/js/interpreters/carbon.js'
+            interpreter_metadata: '/bundles/datadefinitions/pimcore/js/interpreters/metadata.js'
             setter_abstract: '/bundles/datadefinitions/pimcore/js/setters/abstract.js'
             setter_fieldcollection: '/bundles/datadefinitions/pimcore/js/setters/fieldcollection.js'
             setter_objectbrick: '/bundles/datadefinitions/pimcore/js/setters/objectbrick.js'

--- a/src/DataDefinitionsBundle/Resources/config/services.yml
+++ b/src/DataDefinitionsBundle/Resources/config/services.yml
@@ -245,6 +245,12 @@ services:
         tags:
             - { name: data_definitions.interpreter, type: twig, form-type: Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter\TwigInterpreterType }
 
+    Wvision\Bundle\DataDefinitionsBundle\Interpreter\MetadataInterpreter:
+        arguments:
+            - '@service_container'
+        tags:
+            - { name: data_definitions.interpreter, type: metadata, form-type: Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter\MetadataInterpreterType }
+
     ### PROVIDER
     Wvision\Bundle\DataDefinitionsBundle\Provider\CsvProvider:
         tags:
@@ -309,6 +315,10 @@ services:
     Wvision\Bundle\DataDefinitionsBundle\Setter\ObjectTypeSetter:
         tags:
             - { name: data_definitions.setter, type: object_type, form-type: Wvision\Bundle\DataDefinitionsBundle\Form\Type\NoConfigurationType }
+
+    Wvision\Bundle\DataDefinitionsBundle\Setter\RelationSetter:
+        tags:
+            - { name: data_definitions.setter, type: relation, form-type: Wvision\Bundle\DataDefinitionsBundle\Form\Type\NoConfigurationType }
 
     Wvision\Bundle\DataDefinitionsBundle\EventListener\ObjectDeleteListener:
         tags:

--- a/src/DataDefinitionsBundle/Resources/config/services.yml
+++ b/src/DataDefinitionsBundle/Resources/config/services.yml
@@ -246,8 +246,6 @@ services:
             - { name: data_definitions.interpreter, type: twig, form-type: Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter\TwigInterpreterType }
 
     Wvision\Bundle\DataDefinitionsBundle\Interpreter\MetadataInterpreter:
-        arguments:
-            - '@service_container'
         tags:
             - { name: data_definitions.interpreter, type: metadata, form-type: Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter\MetadataInterpreterType }
 

--- a/src/DataDefinitionsBundle/Resources/public/pimcore/js/interpreters/metadata.js
+++ b/src/DataDefinitionsBundle/Resources/public/pimcore/js/interpreters/metadata.js
@@ -1,0 +1,32 @@
+/**
+ * Data Definitions.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2016-2019 w-vision AG (https://www.w-vision.ch)
+ * @license    https://github.com/w-vision/ImportDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ */
+
+pimcore.registerNS('pimcore.plugin.datadefinitions.interpreters.metadata');
+
+pimcore.plugin.datadefinitions.interpreters.metadata = Class.create(pimcore.plugin.datadefinitions.interpreters.abstract, {
+    getLayout: function (fromColumn, toColumn, record, config) {
+        return [{
+            xtype: 'combo',
+            fieldLabel: t('class'),
+            name: 'class',
+            value: config.class ? config.class : null,
+            store: ['ElementMetadata', 'ObjectMetadata'],
+        }, {
+            xtype: 'textfield',
+            fieldLabel: t('metadata'),
+            name: 'metadata',
+            width: 500,
+            value: config.metadata ? config.metadata : null
+        }];
+    }
+});

--- a/src/DataDefinitionsBundle/Setter/KeySetter.php
+++ b/src/DataDefinitionsBundle/Setter/KeySetter.php
@@ -28,7 +28,8 @@ class KeySetter implements SetterInterface
     public function set(Concrete $object, $value, ImportMapping $map, $data)
     {
         $setter = explode('~', $map->getToColumn());
-        $setter = sprintf('set%s', ucfirst($setter[0]));
+        $setter = preg_replace('/^o_/', '', $setter[0]);
+        $setter = sprintf('set%s', ucfirst($setter));
 
         if (method_exists($object, $setter)) {
             $object->$setter(DataObject\Service::getValidKey($value, "object"));

--- a/src/DataDefinitionsBundle/Setter/RelationSetter.php
+++ b/src/DataDefinitionsBundle/Setter/RelationSetter.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Data Definitions.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2016-2019 w-vision AG (https://www.w-vision.ch)
+ * @license    https://github.com/w-vision/DataDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ */
+
+namespace Wvision\Bundle\DataDefinitionsBundle\Setter;
+
+use Pimcore\Model\DataObject\Concrete;
+use Pimcore\Model\DataObject\Fieldcollection\Data\AbstractData as AbstractFieldCollection;
+use Wvision\Bundle\DataDefinitionsBundle\Getter\GetterInterface;
+use Wvision\Bundle\DataDefinitionsBundle\Model\ExportMapping;
+use Wvision\Bundle\DataDefinitionsBundle\Model\ImportMapping;
+use Wvision\Bundle\DataDefinitionsBundle\Model\MappingInterface;
+
+class RelationSetter implements SetterInterface
+{
+    /**
+     * {@inheritdoc}
+     * @throws \Exception
+     */
+    public function set(Concrete $object, $value, ImportMapping $map, $data)
+    {
+        $fieldName = $map->getToColumn();
+        $getter = sprintf('get%s', ucfirst($fieldName));
+        $setter = sprintf('set%s', ucfirst($fieldName));
+
+        $existingElements = $object->$getter();
+        if (!is_array($existingElements)) {
+            $existingElements = [];
+        }
+        
+        // Find unique key (path) for all existing elements
+        $existingKeys = [];
+        foreach ($existingElements as $existingElement) {
+            $existingKeys[] = (string)$existingElement;
+        }
+
+
+        if (!is_array($value)) {
+            $value = [$value];
+        }
+
+        // Add all values that does not already exist. 
+        foreach ($value as $newElement) {
+            $newKey = (string)$newElement;
+            if (!in_array($newKey, $existingKeys)) {
+                $existingElements[] = $newElement;
+            }
+        }
+
+        $object->$setter($existingElements);
+    }
+}
+
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

A small bug fix for the KeySetter. It was not possible to use it on system fields like o_key. It would try to use a setter setO_key.

Added a Metadata interpreter. Before it was not possible to import data to advanced relation fields since those expect ObjectMetadata or ElementMetadata, not Elements. This interpreter fixes that by wrapping the value in one of the Metadata classes. Which class to use is a configuration option in the interpreter. Which one is needed depends on the target relation. There is also a configuration option to add a json string that will be used as metadata for your element. This would typically be used nested with a Asset or ObjectResolver interpreter to wrap your Object/Asset with meta data.

Added a Relation setter. When importing to a relation field, without using a setter, the existing relations will be overwritten. This setter will add new relations but keep the existing ones as well. This allows you to incrementally import new relations without losing the old ones.