### PR TITLE
Add array interpreter

### DIFF
--- a/src/DataDefinitionsBundle/Form/Type/Interpreter/ArrayInterpreterType.php
+++ b/src/DataDefinitionsBundle/Form/Type/Interpreter/ArrayInterpreterType.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Data Definitions.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2016-2019 w-vision AG (https://www.w-vision.ch)
+ * @license    https://github.com/w-vision/DataDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ */
+
+namespace Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class ArrayInterpreterType extends AbstractType
+{
+    /**
+     * @param FormBuilderInterface $builder
+     * @param array                $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('type', TextType::class)
+            ->add('csv_separator', TextType::class);
+    }
+}
+
+

--- a/src/DataDefinitionsBundle/Interpreter/ArrayInterpreter.php
+++ b/src/DataDefinitionsBundle/Interpreter/ArrayInterpreter.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Data Definitions.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2016-2019 w-vision AG (https://www.w-vision.ch)
+ * @license    https://github.com/w-vision/DataDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ */
+
+namespace Wvision\Bundle\DataDefinitionsBundle\Interpreter;
+
+use Pimcore\Model\DataObject\Concrete;
+use Wvision\Bundle\DataDefinitionsBundle\Model\DataDefinitionInterface;
+use Wvision\Bundle\DataDefinitionsBundle\Model\MappingInterface;
+
+class ArrayInterpreter implements InterpreterInterface
+{    
+    /**
+     * {@inheritdoc}
+     */
+    public function interpret(
+        Concrete $object,
+        $value,
+        MappingInterface $map,
+        $data,
+        DataDefinitionInterface $definition,
+        $params,
+        $configuration
+    ) {
+        
+        $type = $configuration['type'];
+        switch ($type) {
+            case 'csv':
+                $value = explode($configuration['csv_separator'], $value);
+                break;
+            case 'json':
+                $value = json_decode($value, true);
+                break;
+            case 'php':
+                $value = unserialize($value);
+                break;
+            default:
+                throw new \InvalidArgumentException(sprintf('Not valid data type given, given %s', $type));
+        }
+        
+        if (!is_array($value)) {
+            throw new \Exception(sprintf('Failed to interpret %s data as array.', $type));
+        }
+
+        return $value;
+    }
+}
+
+

--- a/src/DataDefinitionsBundle/Resources/config/pimcore/config.yml
+++ b/src/DataDefinitionsBundle/Resources/config/pimcore/config.yml
@@ -53,6 +53,7 @@ data_definitions:
             interpreter_twig: '/bundles/datadefinitions/pimcore/js/interpreters/twig.js'
             interpreter_carbon: '/bundles/datadefinitions/pimcore/js/interpreters/carbon.js'
             interpreter_metadata: '/bundles/datadefinitions/pimcore/js/interpreters/metadata.js'
+            interpreter_array: '/bundles/datadefinitions/pimcore/js/interpreters/array.js'
             setter_abstract: '/bundles/datadefinitions/pimcore/js/setters/abstract.js'
             setter_fieldcollection: '/bundles/datadefinitions/pimcore/js/setters/fieldcollection.js'
             setter_objectbrick: '/bundles/datadefinitions/pimcore/js/setters/objectbrick.js'

--- a/src/DataDefinitionsBundle/Resources/config/services.yml
+++ b/src/DataDefinitionsBundle/Resources/config/services.yml
@@ -249,6 +249,10 @@ services:
         tags:
             - { name: data_definitions.interpreter, type: metadata, form-type: Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter\MetadataInterpreterType }
 
+    Wvision\Bundle\DataDefinitionsBundle\Interpreter\ArrayInterpreter:
+        tags:
+            - { name: data_definitions.interpreter, type: array, form-type: Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter\ArrayInterpreterType }
+
     ### PROVIDER
     Wvision\Bundle\DataDefinitionsBundle\Provider\CsvProvider:
         tags:

--- a/src/DataDefinitionsBundle/Resources/public/pimcore/js/interpreters/array.js
+++ b/src/DataDefinitionsBundle/Resources/public/pimcore/js/interpreters/array.js
@@ -1,0 +1,50 @@
+/**
+ * Data Definitions.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2016-2019 w-vision AG (https://www.w-vision.ch)
+ * @license    https://github.com/w-vision/ImportDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ */
+
+pimcore.registerNS('pimcore.plugin.datadefinitions.interpreters.array');
+
+pimcore.plugin.datadefinitions.interpreters.array = Class.create(pimcore.plugin.datadefinitions.interpreters.abstract, {
+    getLayout: function (fromColumn, toColumn, record, config) {
+        var csvSeparatorField = Ext.create({
+            xtype: 'textfield',
+            fieldLabel: t('separator'),
+            name: 'csv_separator',
+            width: 500,
+            hidden: config.type != 'CSV',
+            value: config.csv_separator ? config.csv_separator : ','
+        });
+
+        var typeCombo = Ext.create({
+            xtype: 'combo',
+            fieldLabel: t('type'),
+            name: 'type',
+            value: config.type ? config.type : null,
+            store: [
+                ['json', 'Json'],
+                ['serialized', 'PHP Serialized'],
+                ['csv', 'CSV']
+            ],
+            listeners: {
+                change: function (o, newValue, oldValue, eOpts) {
+                    if (newValue == 'csv') {
+                        csvSeparatorField.setVisible(true);
+                    } else {
+                        csvSeparatorField.setVisible(false);
+                    }
+                }
+            }
+        });
+
+        return [typeCombo, csvSeparatorField];
+    }
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

Adds an interpreter that turns input value into an array. Very useful nested with the Iterator interpreter to cast input data to an actual array.

There are three configuration options for different input values.
**Json** - Input value is a json encoded array
**Php Serialized** - Input value is a serialized php array
**CSV** - Input value is a list of values separated by a given character. For this option there is a second configuration field for the separator character.

