### PR TITLE
Separate import and export providers in select field

### DIFF
--- a/src/DataDefinitionsBundle/Form/Type/ExportDefinitionType.php
+++ b/src/DataDefinitionsBundle/Form/Type/ExportDefinitionType.php
@@ -17,7 +17,6 @@ namespace Wvision\Bundle\DataDefinitionsBundle\Form\Type;
 use CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistryInterface;
 use CoreShop\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -38,25 +37,16 @@ final class ExportDefinitionType extends AbstractResourceType
     private $fetcherFormTypeRegistry;
 
     /**
-     * List of export providers for select field
-     *
-     * @var array<string,string>
-     */
-    private $providers;
-
-    /**
      * {@inheritdoc}
      */
     public function __construct(
         $dataClass,
         array $validationGroups,
-        array $providers,
         FormTypeRegistryInterface $formTypeRegistry,
         FormTypeRegistryInterface $fetcherFormTypeRegistry
     ) {
         parent::__construct($dataClass, $validationGroups);
 
-        $this->providers = $providers;
         $this->formTypeRegistry = $formTypeRegistry;
         $this->fetcherFormTypeRegistry = $fetcherFormTypeRegistry;
     }
@@ -67,7 +57,7 @@ final class ExportDefinitionType extends AbstractResourceType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('provider', ChoiceType::class, ['choices' => $this->providers])
+            ->add('provider', ExportProviderChoiceType::class)
             ->add('fetcher', FetcherChoiceType::class)
             ->add('class', ClassChoiceType::class)
             ->add('runner', ExportRunnerChoiceType::class)

--- a/src/DataDefinitionsBundle/Form/Type/ExportDefinitionType.php
+++ b/src/DataDefinitionsBundle/Form/Type/ExportDefinitionType.php
@@ -17,6 +17,7 @@ namespace Wvision\Bundle\DataDefinitionsBundle\Form\Type;
 use CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistryInterface;
 use CoreShop\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -37,16 +38,25 @@ final class ExportDefinitionType extends AbstractResourceType
     private $fetcherFormTypeRegistry;
 
     /**
+     * List of export providers for select field
+     *
+     * @var array<string,string>
+     */
+    private $providers;
+
+    /**
      * {@inheritdoc}
      */
     public function __construct(
         $dataClass,
         array $validationGroups,
+        array $providers,
         FormTypeRegistryInterface $formTypeRegistry,
         FormTypeRegistryInterface $fetcherFormTypeRegistry
     ) {
         parent::__construct($dataClass, $validationGroups);
 
+        $this->providers = $providers;
         $this->formTypeRegistry = $formTypeRegistry;
         $this->fetcherFormTypeRegistry = $fetcherFormTypeRegistry;
     }
@@ -57,7 +67,7 @@ final class ExportDefinitionType extends AbstractResourceType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('provider', ProviderChoiceType::class)
+            ->add('provider', ChoiceType::class, ['choices' => $this->providers])
             ->add('fetcher', FetcherChoiceType::class)
             ->add('class', ClassChoiceType::class)
             ->add('runner', ExportRunnerChoiceType::class)

--- a/src/DataDefinitionsBundle/Form/Type/ExportProviderChoiceType.php
+++ b/src/DataDefinitionsBundle/Form/Type/ExportProviderChoiceType.php
@@ -1,4 +1,16 @@
 <?php
+/**
+ * Data Definitions.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2016-2019 w-vision AG (https://www.w-vision.ch)
+ * @license    https://github.com/w-vision/DataDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ */
 
 namespace Wvision\Bundle\DataDefinitionsBundle\Form\Type;
 

--- a/src/DataDefinitionsBundle/Form/Type/ExportProviderChoiceType.php
+++ b/src/DataDefinitionsBundle/Form/Type/ExportProviderChoiceType.php
@@ -1,16 +1,4 @@
 <?php
-/**
- * Data Definitions.
- *
- * LICENSE
- *
- * This source file is subject to the GNU General Public License version 3 (GPLv3)
- * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
- * files that are distributed with this source code.
- *
- * @copyright  Copyright (c) 2016-2019 w-vision AG (https://www.w-vision.ch)
- * @license    https://github.com/w-vision/DataDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
- */
 
 namespace Wvision\Bundle\DataDefinitionsBundle\Form\Type;
 
@@ -18,15 +6,17 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-final class ProviderChoiceType extends AbstractType
+final class ExportProviderChoiceType extends AbstractType
 {
     /**
-     * @var array
+     * List of providers available to choose
+     *
+     * @var array<string,string>
      */
     private $providers;
 
     /**
-     * @param array $providers
+     * @param array<string,string> $providers
      */
     public function __construct(array $providers)
     {
@@ -51,4 +41,3 @@ final class ProviderChoiceType extends AbstractType
         return ChoiceType::class;
     }
 }
-

--- a/src/DataDefinitionsBundle/Form/Type/ImportDefinitionType.php
+++ b/src/DataDefinitionsBundle/Form/Type/ImportDefinitionType.php
@@ -17,6 +17,7 @@ namespace Wvision\Bundle\DataDefinitionsBundle\Form\Type;
 use CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistryInterface;
 use CoreShop\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -32,12 +33,24 @@ final class ImportDefinitionType extends AbstractResourceType
     private $formTypeRegistry;
 
     /**
+     * List of import providers for select field
+     *
+     * @var array<string,string>
+     */
+    private $providers;
+
+    /**
      * {@inheritdoc}
      */
-    public function __construct($dataClass, array $validationGroups, FormTypeRegistryInterface $formTypeRegistry)
-    {
+    public function __construct(
+        $dataClass,
+        array $validationGroups,
+        array $providers,
+        FormTypeRegistryInterface $formTypeRegistry
+    ) {
         parent::__construct($dataClass, $validationGroups);
 
+        $this->providers = $providers;
         $this->formTypeRegistry = $formTypeRegistry;
     }
 
@@ -47,7 +60,7 @@ final class ImportDefinitionType extends AbstractResourceType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('provider', ProviderChoiceType::class)
+            ->add('provider', ChoiceType::class, ['choices' => $this->providers])
             ->add('loader', LoaderChoiceType::class)
             ->add('class', ClassChoiceType::class)
             ->add('cleaner', CleanerChoiceType::class)

--- a/src/DataDefinitionsBundle/Form/Type/ImportDefinitionType.php
+++ b/src/DataDefinitionsBundle/Form/Type/ImportDefinitionType.php
@@ -17,7 +17,6 @@ namespace Wvision\Bundle\DataDefinitionsBundle\Form\Type;
 use CoreShop\Bundle\ResourceBundle\Form\Registry\FormTypeRegistryInterface;
 use CoreShop\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -33,24 +32,15 @@ final class ImportDefinitionType extends AbstractResourceType
     private $formTypeRegistry;
 
     /**
-     * List of import providers for select field
-     *
-     * @var array<string,string>
-     */
-    private $providers;
-
-    /**
      * {@inheritdoc}
      */
     public function __construct(
         $dataClass,
         array $validationGroups,
-        array $providers,
         FormTypeRegistryInterface $formTypeRegistry
     ) {
         parent::__construct($dataClass, $validationGroups);
 
-        $this->providers = $providers;
         $this->formTypeRegistry = $formTypeRegistry;
     }
 
@@ -60,7 +50,7 @@ final class ImportDefinitionType extends AbstractResourceType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('provider', ChoiceType::class, ['choices' => $this->providers])
+            ->add('provider', ImportProviderChoiceType::class)
             ->add('loader', LoaderChoiceType::class)
             ->add('class', ClassChoiceType::class)
             ->add('cleaner', CleanerChoiceType::class)

--- a/src/DataDefinitionsBundle/Form/Type/ImportProviderChoiceType.php
+++ b/src/DataDefinitionsBundle/Form/Type/ImportProviderChoiceType.php
@@ -1,4 +1,16 @@
 <?php
+/**
+ * Data Definitions.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2016-2019 w-vision AG (https://www.w-vision.ch)
+ * @license    https://github.com/w-vision/DataDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ */
 
 namespace Wvision\Bundle\DataDefinitionsBundle\Form\Type;
 

--- a/src/DataDefinitionsBundle/Form/Type/ImportProviderChoiceType.php
+++ b/src/DataDefinitionsBundle/Form/Type/ImportProviderChoiceType.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Wvision\Bundle\DataDefinitionsBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class ImportProviderChoiceType extends AbstractType
+{
+    /**
+     * List of providers available to choose
+     *
+     * @var array<string,string>
+     */
+    private $providers;
+
+    /**
+     * @param array<string,string> $providers
+     */
+    public function __construct(array $providers)
+    {
+        $this->providers = $providers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'choices' => array_flip($this->providers),
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return ChoiceType::class;
+    }
+}

--- a/src/DataDefinitionsBundle/Resources/config/services/forms.yml
+++ b/src/DataDefinitionsBundle/Resources/config/services/forms.yml
@@ -31,11 +31,6 @@ services:
         tags:
             - { name: form.type }
 
-    Wvision\Bundle\DataDefinitionsBundle\Form\Type\ProviderChoiceType:
-        arguments: ['%data_definitions.import_providers%']
-        tags:
-            - { name: form.type }
-
     Wvision\Bundle\DataDefinitionsBundle\Form\Type\LoaderChoiceType:
         arguments: ['%data_definitions.loaders%']
         tags:
@@ -55,6 +50,7 @@ services:
         arguments:
             - '%data_definitions.model.import_definition.class%'
             - '%data_definitions.form.type.definition.validation_groups%'
+            - '%data_definitions.import_providers%'
             - '@data_definitions.form.registry.provider'
         tags:
             - { name: form.type }
@@ -78,6 +74,7 @@ services:
         arguments:
             - '%data_definitions.model.export_definition.class%'
             - '%data_definitions.form.type.export_definition.validation_groups%'
+            - '%data_definitions.export_providers%'
             - '@data_definitions.form.registry.export_provider'
             - '@data_definitions.form.registry.fetcher'
         tags:

--- a/src/DataDefinitionsBundle/Resources/config/services/forms.yml
+++ b/src/DataDefinitionsBundle/Resources/config/services/forms.yml
@@ -31,6 +31,16 @@ services:
         tags:
             - { name: form.type }
 
+    Wvision\Bundle\DataDefinitionsBundle\Form\Type\ImportProviderChoiceType:
+        arguments: ['%data_definitions.import_providers%']
+        tags:
+            - { name: form.type }
+
+    Wvision\Bundle\DataDefinitionsBundle\Form\Type\ExportProviderChoiceType:
+        arguments: ['%data_definitions.export_providers%']
+        tags:
+            - { name: form.type }
+
     Wvision\Bundle\DataDefinitionsBundle\Form\Type\LoaderChoiceType:
         arguments: ['%data_definitions.loaders%']
         tags:
@@ -50,7 +60,6 @@ services:
         arguments:
             - '%data_definitions.model.import_definition.class%'
             - '%data_definitions.form.type.definition.validation_groups%'
-            - '%data_definitions.import_providers%'
             - '@data_definitions.form.registry.provider'
         tags:
             - { name: form.type }
@@ -74,7 +83,6 @@ services:
         arguments:
             - '%data_definitions.model.export_definition.class%'
             - '%data_definitions.form.type.export_definition.validation_groups%'
-            - '%data_definitions.export_providers%'
             - '@data_definitions.form.registry.export_provider'
             - '@data_definitions.form.registry.fetcher'
         tags:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #238 

Providers injections into import/export form types instead of using the common custom select