### PR TITLE
Delete `data_definitions_import_log` table if `import_definitions_log…

### DIFF
--- a/src/DataDefinitionsBundle/Migrations/Version20190731104917.php
+++ b/src/DataDefinitionsBundle/Migrations/Version20190731104917.php
@@ -13,6 +13,11 @@ class Version20190731104917 extends AbstractPimcoreMigration
     public function up(Schema $schema)
     {
         if ($schema->hasTable('import_definitions_log')) {
+            // delete just created table before renaming the old table
+            if ($schema->hasTable('data_definitions_import_log')) {
+                $this->addSql("DROP TABLE `data_definitions_import_log`");
+            }
+
             $this->addSql('ALTER TABLE `import_definitions_log` RENAME TO `data_definitions_import_log`;');
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #240 

Delete the brand new table before renaming if the old one is already exists
