### PR TITLE
fix: run the export process even with zero items

### DIFF
--- a/src/DataDefinitionsBundle/Command/ExportCommand.php
+++ b/src/DataDefinitionsBundle/Command/ExportCommand.php
@@ -116,9 +116,12 @@ EOT
         };
 
         $imTotal = function (ExportDefinitionEvent $e) use ($output, $definition, &$progress, &$process) {
-            $progress = new ProgressBar($output, $e->getSubject());
-            $progress->setFormat(' %current%/%max% [%bar%] %percent:3s%% (%elapsed:6s%/%estimated:-6s%) %memory:6s%: %message%');
-            $progress->start();
+            $total = $e->getSubject();
+            if ($total > 0) {
+                $progress = new ProgressBar($output, $total);
+                $progress->setFormat(' %current%/%max% [%bar%] %percent:3s%% (%elapsed:6s%/%estimated:-6s%) %memory:6s%: %message%');
+                $progress->start();
+            }
         };
 
         $imProgress = function (ExportDefinitionEvent $e) use ($output, &$progress, &$process) {
@@ -131,6 +134,8 @@ EOT
             if ($progress instanceof ProgressBar) {
                 $progress->finish();
                 $output->writeln('');
+            } else {
+                $output->writeln('<info>No items to export</info>');
             }
 
             $output->writeln('Export finished!');

--- a/src/DataDefinitionsBundle/Exporter/Exporter.php
+++ b/src/DataDefinitionsBundle/Exporter/Exporter.php
@@ -110,12 +110,10 @@ final class Exporter implements ExporterInterface
         $total = $fetcher->count($definition, $params,
             is_array($definition->getFetcherConfig()) ? $definition->getFetcherConfig() : []);
 
-        if ($total > 0) {
-            $this->eventDispatcher->dispatch('data_definitions.export.total',
-                new ExportDefinitionEvent($definition, $total, $params));
+        $this->eventDispatcher->dispatch('data_definitions.export.total',
+            new ExportDefinitionEvent($definition, $total, $params));
 
-            $this->runExport($definition, $params, $total, $fetcher, $provider);
-        }
+        $this->runExport($definition, $params, $total, $fetcher, $provider);
 
         $this->eventDispatcher->dispatch('data_definitions.export.finished',
             new ExportDefinitionEvent($definition, null, $params));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #237 

This ensures the export process always runs fully, even with zero results, creating an empty artifact where expected.

Closes #237 .