### PR TITLE
Fix config keys for fieldcollection setter

### DIFF
--- a/src/DataDefinitionsBundle/Setter/FieldCollectionSetter.php
+++ b/src/DataDefinitionsBundle/Setter/FieldCollectionSetter.php
@@ -32,8 +32,8 @@ class FieldCollectionSetter implements SetterInterface, GetterInterface
         $keyParts = explode('~', $map->getToColumn());
 
         $config = $map->getSetterConfig();
-        $keys = $config['fieldcollectionKeys'];
-        $fieldName = $config['fieldcollectionField'];
+        $keys = $config['keys'];
+        $fieldName = $config['field'];
         $class = $config['class'];
         $keys = explode(',', $keys);
         $fieldCollectionClass = 'Pimcore\Model\DataObject\Fieldcollection\Data\\'.ucfirst($class);


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

There is only 3 parameters in the config array, "fieldcollectionField" and "fieldcollectionKeys" does not exist but "field" and "keys" exist. and now it work. (thx for your work)
