### PR TITLE
Invalid typehint type Mapping on InterpreterInterface

### DIFF
--- a/src/DataDefinitionsBundle/Interpreter/InterpreterInterface.php
+++ b/src/DataDefinitionsBundle/Interpreter/InterpreterInterface.php
@@ -24,7 +24,7 @@ interface InterpreterInterface
     /**
      * @param Concrete            $object
      * @param                     $value
-     * @param Mapping             $map
+     * @param MappingInterface    $map
      * @param array               $data
      * @param DataDefinitionInterface $definition
      * @param array               $params


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

The parameter `$map` of method `...::interpret()` has invalid typehint type `Wvision\Bundle\DataDefinitionsBundle\Interpreter\Mapping`.
