### PR TITLE
Added possibility to set user for an import.

### DIFF
--- a/src/DataDefinitionsBundle/Command/ImportCommand.php
+++ b/src/DataDefinitionsBundle/Command/ImportCommand.php
@@ -90,7 +90,11 @@ EOT
     {
         $eventDispatcher = $this->eventDispatcher;
 
-        $params = $input->getOption('params');
+        $params = json_decode($input->getOption('params'), true);
+        if (!$params['userId']) {
+            $params['userId'] = 0;
+        }
+
         try {
             $definition = $this->repository->find($input->getOption('definition'));
         } catch (\InvalidArgumentException $e) {
@@ -155,7 +159,7 @@ EOT
         $eventDispatcher->addListener('data_definitions.import.progress', $imProgress);
         $eventDispatcher->addListener('data_definitions.import.finished', $imFinished);
 
-        $this->importer->doImport($definition, json_decode($params, true));
+        $this->importer->doImport($definition, $params);
 
         $eventDispatcher->removeListener('data_definitions.import.status', $imStatus);
         $eventDispatcher->removeListener('data_definitions.import.status.child', $imStatus);

--- a/src/DataDefinitionsBundle/Importer/Importer.php
+++ b/src/DataDefinitionsBundle/Importer/Importer.php
@@ -391,7 +391,7 @@ final class Importer implements ImporterInterface
         }
 
         if ($shouldSave) {
-            $object->setUserModification(0); //Set User to "system"
+            $object->setUserModification($params['userId'] ?? 0);
             $object->setOmitMandatoryCheck($definition->getOmitMandatoryCheck());
             $object->save();
 

--- a/src/DataDefinitionsBundle/ProcessManager/ImportDefinitionProcess.php
+++ b/src/DataDefinitionsBundle/ProcessManager/ImportDefinitionProcess.php
@@ -14,6 +14,7 @@
 
 namespace Wvision\Bundle\DataDefinitionsBundle\ProcessManager;
 
+use Pimcore\Tool\Admin;
 use ProcessManagerBundle\Model\ExecutableInterface;
 use ProcessManagerBundle\Process\Pimcore;
 
@@ -25,9 +26,14 @@ final class ImportDefinitionProcess extends Pimcore
     public function run(ExecutableInterface $executable, array $params = null)
     {
         $settings = $executable->getSettings();
+        $params = json_decode($settings['params']);
+        $currentUser = Admin::getCurrentUser();
+        if ($currentUser && !$params->userId) {
+            $params->userId = $currentUser->getId();
+        }
 
         $settings['command'] = sprintf('data-definitions:import -d %s -p "%s"', $settings['definition'],
-            addslashes($settings['params']));
+            addslashes(json_encode($params)));
 
         $executable->setSettings($settings);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no

This PR allows setting `userId` parameter to an import. It will be used then to mark modificationUser of an object. 
This could be useful if importer is used in an integration - e.g. we can mark user as `erp`.
Also if import was started using Process Manager - current user will be set.