### PR TITLE
DoNotSetOnEmptyInterpreter.

### DIFF
--- a/src/DataDefinitionsBundle/Interpreter/CheckboxInterpreter.php
+++ b/src/DataDefinitionsBundle/Interpreter/CheckboxInterpreter.php
@@ -37,10 +37,15 @@ class CheckboxInterpreter implements InterpreterInterface, DataSetAwareInterface
         $params,
         $configuration
     ) {
-        if ($value === "") {
-            return null;
+        if (is_string($value)) {
+            if ($value === "") {
+                return null;
+            }
+
+            return filter_var(strtolower($value), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
         }
-        return filter_var(strtolower($value), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+        return (boolval($value));
     }
 }
 

--- a/src/DataDefinitionsBundle/Interpreter/DoNotSetOnEmptyInterpreter.php
+++ b/src/DataDefinitionsBundle/Interpreter/DoNotSetOnEmptyInterpreter.php
@@ -8,7 +8,7 @@
  * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
  * files that are distributed with this source code.
  *
- * @copyright  Copyright (c) 2016 W-Vision (http://www.w-vision.ch)
+ * @copyright  Copyright (c) 2016-2019 w-vision AG (https://www.w-vision.ch)
  * @license    https://github.com/w-vision/DataDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
  */
 
@@ -21,10 +21,10 @@ use Wvision\Bundle\DataDefinitionsBundle\Model\DataSetAwareTrait;
 use Wvision\Bundle\DataDefinitionsBundle\Model\DataDefinitionInterface;
 use Wvision\Bundle\DataDefinitionsBundle\Model\MappingInterface;
 
-class CheckboxInterpreter implements InterpreterInterface, DataSetAwareInterface
+class DoNotSetOnEmptyInterpreter implements InterpreterInterface, DataSetAwareInterface
 {
     use DataSetAwareTrait;
-
+    
     /**
      * {@inheritdoc}
      */
@@ -37,10 +37,15 @@ class CheckboxInterpreter implements InterpreterInterface, DataSetAwareInterface
         $params,
         $configuration
     ) {
-        if ($value === "") {
-            return null;
+        if ($value === "" || $value === null) {
+            throw new DoNotSetException();
         }
-        return filter_var(strtolower($value), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+        if (is_array($value) && count($value) == 0) {
+            throw new DoNotSetException();
+        }
+
+        return $value;
     }
 }
 

--- a/src/DataDefinitionsBundle/Interpreter/DoNotSetOnEmptyInterpreter.php
+++ b/src/DataDefinitionsBundle/Interpreter/DoNotSetOnEmptyInterpreter.php
@@ -24,7 +24,7 @@ use Wvision\Bundle\DataDefinitionsBundle\Model\MappingInterface;
 class DoNotSetOnEmptyInterpreter implements InterpreterInterface, DataSetAwareInterface
 {
     use DataSetAwareTrait;
-    
+
     /**
      * {@inheritdoc}
      */
@@ -41,7 +41,7 @@ class DoNotSetOnEmptyInterpreter implements InterpreterInterface, DataSetAwareIn
             throw new DoNotSetException();
         }
 
-        if (is_array($value) && count($value) == 0) {
+        if (is_array($value) && count($value) === 0) {
             throw new DoNotSetException();
         }
 

--- a/src/DataDefinitionsBundle/Resources/config/services.yml
+++ b/src/DataDefinitionsBundle/Resources/config/services.yml
@@ -249,6 +249,10 @@ services:
         tags:
             - { name: data_definitions.interpreter, type: twig, form-type: Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter\TwigInterpreterType }
 
+    Wvision\Bundle\DataDefinitionsBundle\Interpreter\DoNotSetOnEmptyInterpreter:
+      tags:
+        - { name: data_definitions.interpreter, type: donotsetonempty, form-type: Wvision\Bundle\DataDefinitionsBundle\Form\Type\NoConfigurationType }
+
     ### PROVIDER
     Wvision\Bundle\DataDefinitionsBundle\Provider\CsvProvider:
         tags:


### PR DESCRIPTION
Interpreter that will cause DoNotSetException if passed value is empty. Can be chained in nested interpreter to break interpretation or as in my case - do not change the the checkbox to false (or null) if the value is empty.
To achieve the latter, a change was also needed in checkbox interpreter. `filter_var` with used flags returned false on empty string.
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
