### PR TITLE
Fix 'getDuplicatedAsset' returning boolean values

### DIFF
--- a/src/DataDefinitionsBundle/Interpreter/AssetUrlInterpreter.php
+++ b/src/DataDefinitionsBundle/Interpreter/AssetUrlInterpreter.php
@@ -197,6 +197,8 @@ class AssetUrlInterpreter implements InterpreterInterface, DataSetAwareInterface
         $listing->setLimit(1);
         $listing->setOrder(['creationDate', 'desc']);
 
-        return $listing->current();
+        $duplicatedAssets = $listing->getAssets();
+        
+        return empty($duplicatedAssets) === false ? $duplicatedAssets[0] : null;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

In some cases `$listing->current()` is returning a boolean value which triggers an error because of the type hinting. 