### PR TITLE
Don't use deprecated alias 'coreshop.resource_registry'

### DIFF
--- a/src/DataDefinitionsBundle/Resources/config/services/commands.yml
+++ b/src/DataDefinitionsBundle/Resources/config/services/commands.yml
@@ -29,7 +29,7 @@ services:
 
     Wvision\Bundle\DataDefinitionsBundle\Command\ImportImportDefinitionCommand:
         arguments:
-            - "@=service('coreshop.resource_registry').get('data_definitions.import_definition')"
+            - '@=service("CoreShop\\Component\\Resource\\Metadata\\RegistryInterface").get("data_definitions.import_definition")'
             - '@data_definitions.repository.import_definition'
             - '@CoreShop\Bundle\ResourceBundle\Pimcore\ObjectManager'
             - '@CoreShop\Bundle\ResourceBundle\Controller\ResourceFormFactoryInterface'
@@ -38,7 +38,7 @@ services:
 
     Wvision\Bundle\DataDefinitionsBundle\Command\ImportExportDefinitionCommand:
         arguments:
-            - "@=service('coreshop.resource_registry').get('data_definitions.export_definition')"
+            - '@=service("CoreShop\\Component\\Resource\\Metadata\\RegistryInterface").get("data_definitions.export_definition")'
             - '@data_definitions.repository.export_definition'
             - '@CoreShop\Bundle\ResourceBundle\Pimcore\ObjectManager'
             - '@CoreShop\Bundle\ResourceBundle\Controller\ResourceFormFactoryInterface'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes

I was getting errors about the coreshop.resource_registry service not being public. Noticed it is deprecated in the Coreshop Resource bundle. So I replaced the alias in the service definition for the import/export commands.
