### PR TITLE
Fix mapping interpreter checkbox

### DIFF
--- a/src/DataDefinitionsBundle/Resources/public/pimcore/js/interpreters/mapping.js
+++ b/src/DataDefinitionsBundle/Resources/public/pimcore/js/interpreters/mapping.js
@@ -111,7 +111,8 @@ pimcore.plugin.datadefinitions.interpreters.mapping = Class.create(pimcore.plugi
                     from: rec.data.from,
                     to: rec.data.to
                 };
-            })
+            }),
+            return_null_when_not_found: this.checkbox.getSubmitValue()
         };
     }
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Fixed "Null when not found" checkbox in import definitions mapping interpreter. 
Previously it wouldn't save and always evaluate to false.