### PR TITLE
Allow any iterable type on value rather than only arrays

### DIFF
--- a/src/DataDefinitionsBundle/Setter/RelationSetter.php
+++ b/src/DataDefinitionsBundle/Setter/RelationSetter.php
@@ -45,7 +45,7 @@ class RelationSetter implements SetterInterface
         }
 
 
-        if (!is_array($value)) {
+        if (!is_iterable($value)) {
             $value = [$value];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |

In the relation setter the value is assumed to be either a single data object or an array of objects. By using `is_iterable` instead of `is_array` we can allow any type of iterable for example a `Listing`.