### PR TITLE
fix: ensure a stable sort across pages + artifact regression

### DIFF
--- a/src/DataDefinitionsBundle/Fetcher/ObjectsFetcher.php
+++ b/src/DataDefinitionsBundle/Fetcher/ObjectsFetcher.php
@@ -94,6 +94,10 @@ class ObjectsFetcher implements FetcherInterface
         }
         
         $list->setCondition(implode(' AND ', $conditionFilters));
+        
+        // ensure a stable sort across pages
+        $list->setOrderKey('o_id');
+        $list->setOrder('asc');
 
         return $list;
     }

--- a/src/DataDefinitionsBundle/ProcessManager/ProcessManagerExportListener.php
+++ b/src/DataDefinitionsBundle/ProcessManager/ProcessManagerExportListener.php
@@ -59,10 +59,12 @@ final class ProcessManagerExportListener extends AbstractProcessManagerListener
                         $event->getParams()
                     );
 
-                    if ($artifact instanceof Asset) {
-                        $this->process->setArtifact($artifact);
-                        $this->process->save();
+                    if (null === $artifact) {
+                        return;
                     }
+
+                    $this->process->setArtifact($artifact);
+                    $this->process->save();
                 }
             }
         }


### PR DESCRIPTION
If doing pagination, the order is important since you're relying on it being stable across pages to actually walk through the intended dataset.

If the ORDER BY is not specified, the actual order is undefined, meaning you can get pages skipped and duplicated. It will mostly work because the same order is kept, but sometimes it might fail (as in my case, on MariaDB 10). The issue is, it didn't always fail, only sometimes (on some pages), being totally unpredictable and requiring a large amount of debugging.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
