### PR TITLE
Support for class overrides

### DIFF
--- a/src/DataDefinitionsBundle/Importer/Importer.php
+++ b/src/DataDefinitionsBundle/Importer/Importer.php
@@ -21,6 +21,7 @@ use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\Service;
 use Pimcore\Model\Document;
+use Pimcore\Model\Factory;
 use Pimcore\Model\Version;
 use Pimcore\Placeholder;
 use Psr\Log\LoggerAwareInterface;
@@ -88,6 +89,9 @@ final class Importer implements ImporterInterface
      */
     private $logger;
 
+    /** @var Factory */
+    private $modelFactory;
+
     /**
      * @var bool
      */
@@ -104,6 +108,7 @@ final class Importer implements ImporterInterface
      * @param ServiceRegistryInterface $loaderRegistry
      * @param EventDispatcherInterface $eventDispatcher
      * @param LoggerInterface $logger
+     * @param Factory $modelFactory
      */
     public function __construct(
         ServiceRegistryInterface $providerRegistry,
@@ -114,7 +119,8 @@ final class Importer implements ImporterInterface
         ServiceRegistryInterface $cleanerRegistry,
         ServiceRegistryInterface $loaderRegistry,
         EventDispatcherInterface $eventDispatcher,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        Factory $modelFactory
     ) {
         $this->providerRegistry = $providerRegistry;
         $this->filterRegistry = $filterRegistry;
@@ -125,6 +131,7 @@ final class Importer implements ImporterInterface
         $this->loaderRegistry = $loaderRegistry;
         $this->eventDispatcher = $eventDispatcher;
         $this->logger = $logger;
+        $this->modelFactory = $modelFactory;
     }
 
     /**
@@ -588,7 +595,8 @@ final class Importer implements ImporterInterface
         $obj = $loader->load($class, $data, $definition, $params);
 
         if (null === $obj) {
-            $obj = new $classObject();
+            $classImplementation = $this->modelFactory->getClassNameFor($classObject) ?? $classObject;
+            $obj = new $classImplementation();
         }
 
         $key = Service::getValidKey($this->createKey($definition, $data), 'object');

--- a/src/DataDefinitionsBundle/Resources/config/services.yml
+++ b/src/DataDefinitionsBundle/Resources/config/services.yml
@@ -26,6 +26,7 @@ services:
             - '@data_definitions.registry.loader'
             - '@Wvision\Bundle\DataDefinitionsBundle\Event\EventDispatcher'
             - '@logger'
+            - '@pimcore.model.factory'
         tags:
             - { name: monolog.logger, channel: import_definition }
             - { name: 'kernel.event_listener', event: 'data_definitions.stop', method: 'stop' }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->

Added support for Pimcore model class overrides (see: https://pimcore.com/docs/pimcore/current/Development_Documentation/Extending_Pimcore/Overriding_Models.html)

Currently the Importer always instantiates a default model (`Pimcore\Model\DataObject\...`) instead of checking if there is an override configured (i.e. `App\Model\DataObject\...`).
