### PR TITLE
Prevent undefined index 'custom' exception

### DIFF
--- a/src/DataDefinitionsBundle/Importer/Importer.php
+++ b/src/DataDefinitionsBundle/Importer/Importer.php
@@ -364,7 +364,7 @@ final class Importer implements ImporterInterface
             $value = null;
 
             if (array_key_exists($mapItem->getFromColumn(), $data) || $mapItem->getFromColumn() === "custom") {
-                $value = $data[$mapItem->getFromColumn()];
+                $value = $data[$mapItem->getFromColumn()] ?? null;
                 $this->setObjectValue($object, $mapItem, $value, $data, $dataSet, $definition, $params, $runner);
             }
         }


### PR DESCRIPTION
Prevent undefined index 'custom' and set $value to null with null coalescing operator.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | no ticket as fas as i know

<!--
With testing my code I keep getting the exception 'Undefined index: custom'. Using the null coalescing operator and setting null when index 'custom' doesn't exist fixes that.
-->
