### PR TITLE
Fix error when saving a configuration for MultiHrefInterpreter

### DIFF
--- a/src/DataDefinitionsBundle/Form/Type/Interpreter/MultiHrefInterpreterType.php
+++ b/src/DataDefinitionsBundle/Form/Type/Interpreter/MultiHrefInterpreterType.php
@@ -15,7 +15,6 @@
 namespace Wvision\Bundle\DataDefinitionsBundle\Form\Type\Interpreter;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 final class MultiHrefInterpreterType extends AbstractType
@@ -23,10 +22,9 @@ final class MultiHrefInterpreterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function getParent()
     {
-        $builder
-            ->add('class', TextType::class);
+        return HrefInterpreterType::class;
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

Field `type` is missing in FormType causing `This form should not contain extra fields.`
![Screenshot from 2021-02-23 22-29-40](https://user-images.githubusercontent.com/16133208/108911567-b22c9380-7627-11eb-92b1-d339fbb7887b.png)
Extend `HrefInterpreter` form type, as it happens for the ExtJS part, since the configurations are the same.
