### PR TITLE
fix: interpret passing an empty string to QuantityValue as null

### DIFF
--- a/src/DataDefinitionsBundle/Interpreter/QuantityValueInterpreter.php
+++ b/src/DataDefinitionsBundle/Interpreter/QuantityValueInterpreter.php
@@ -36,6 +36,7 @@ class QuantityValueInterpreter implements InterpreterInterface, DataSetAwareInte
         $params,
         $configuration
     ) {
+        $value = $value !== '' ? $value : null;
         $unit = $configuration['unit'];
 
         return new \Pimcore\Model\DataObject\Data\QuantityValue($value, $unit);


### PR DESCRIPTION
If passing an empty string to QuantityValue in a Classification store, it will be interpreted as 0, but should be as a `null`.

See https://github.com/pimcore/pimcore/issues/8277 for another related issue.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A