### PR TITLE
Feat/interpreter exception

### DIFF
--- a/src/DataDefinitionsBundle/Exception/InterpreterException.php
+++ b/src/DataDefinitionsBundle/Exception/InterpreterException.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Data Definitions.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2016-2019 w-vision AG (https://www.w-vision.ch)
+ * @license    https://github.com/w-vision/DataDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ */
+
+namespace Wvision\Bundle\DataDefinitionsBundle\Exception;
+
+use Wvision\Bundle\DataDefinitionsBundle\Model\DataDefinitionInterface;
+use Wvision\Bundle\DataDefinitionsBundle\Model\MappingInterface;
+
+class InterpreterException extends \RuntimeException
+{
+    private function __construct(DataDefinitionInterface $definition, MappingInterface $mapping, array $params, $value, ?\Throwable $previous = null)
+    {
+        parent::__construct($this->formatMessage($definition, $mapping, $params, $value, $previous), null, $previous);
+    }
+
+    public static function fromInterpreter(DataDefinitionInterface $definition, MappingInterface $mapping, array $params, $value, ?\Throwable $previous = null)
+    {
+        return new self($definition, $mapping, $params, $value, $previous);
+    }
+
+    private function formatMessage(DataDefinitionInterface $definition, MappingInterface $mapping, array $params, $value, ?\Throwable $previous = null): string
+    {
+        $format = '%1$s, %2$s';
+        if ($previous !== null) {
+            $format = '%1$s, %2$s: %3$s';
+        }
+
+        return sprintf($format, $this->formatDefinition($definition), $this->formatSource($mapping, $value, $params['row'] ?? null), $previous ? $previous->getMessage() : null);
+    }
+
+    private function formatDefinition(DataDefinitionInterface $definition): string
+    {
+        return sprintf('%1$s (ID %2$d)', $definition->getName(), $definition->getId());
+    }
+
+    private function formatSource(MappingInterface $mapping, $value, ?int $row = null): string
+    {
+        $format = 'from "%1$s" to "%2$s" (using interpreter "%3$s", config %4$s), got value %6$s';
+        if ($row !== null) {
+            $format = 'from "%1$s" (row %5$d) to "%2$s" (interpreter "%3$s", config %4$s), got value %6$s';
+        }
+
+        return sprintf($format, $mapping->getFromColumn(), $mapping->getToColumn(), $mapping->getInterpreter(), var_export_pretty($mapping->getInterpreterConfig()), $row, $this->formatValue($value));
+    }
+
+    private function formatValue($value): string
+    {
+        return var_export_pretty($value);
+    }
+}

--- a/src/DataDefinitionsBundle/Importer/Importer.php
+++ b/src/DataDefinitionsBundle/Importer/Importer.php
@@ -303,7 +303,7 @@ final class Importer implements ImporterInterface
 
         foreach ($dataSet as $row) {
             try {
-                $object = $this->importRow($definition, $row, $dataSet, $params, $filter);
+                $object = $this->importRow($definition, $row, $dataSet, array_merge($params, ['row' => $count]), $filter);
 
                 if ($object instanceof Concrete) {
                     $objectIds[] = $object->getId();

--- a/src/DataDefinitionsBundle/Interpreter/ExpressionInterpreter.php
+++ b/src/DataDefinitionsBundle/Interpreter/ExpressionInterpreter.php
@@ -17,6 +17,7 @@ namespace Wvision\Bundle\DataDefinitionsBundle\Interpreter;
 use Pimcore\Model\DataObject\Concrete;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Wvision\Bundle\DataDefinitionsBundle\Exception\InterpreterException;
 use Wvision\Bundle\DataDefinitionsBundle\Model\DataSetAwareInterface;
 use Wvision\Bundle\DataDefinitionsBundle\Model\DataSetAwareTrait;
 use Wvision\Bundle\DataDefinitionsBundle\Model\DataDefinitionInterface;
@@ -60,16 +61,20 @@ class ExpressionInterpreter implements InterpreterInterface, DataSetAwareInterfa
     ) {
         $expression = $configuration['expression'];
 
-        return $this->expressionLanguage->evaluate($expression, [
-            'value' => $value,
-            'object' => $object,
-            'map' => $map,
-            'data' => $data,
-            'definition' => $definition,
-            'params' => $params,
-            'configuration' => $configuration,
-            'container' => $this->container,
-        ]);
+        try {
+            return $this->expressionLanguage->evaluate($expression, [
+                'value' => $value,
+                'object' => $object,
+                'map' => $map,
+                'data' => $data,
+                'definition' => $definition,
+                'params' => $params,
+                'configuration' => $configuration,
+                'container' => $this->container,
+            ]);
+        } catch (\Throwable $exception) {
+            throw InterpreterException::fromInterpreter($definition, $map, $params, $value, $exception);
+        }
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #181 

Example exception thrown
```
Products [XLSX] Price History and Models (ID 181), from "LaunchDate" (row 1) to "LaunchDate" (interpreter "expression", config [
    "expression" => "implode(value, ' 00:00:00')"
]), value DateTime::__set_state(array(
   'date' => '2020-07-01 00:00:00.000000',
   'timezone_type' => 3,
   'timezone' => 'Europe/Berlin',
)): Warning: implode(): Invalid arguments passed
```

The wording is just a first draft to get the ball rolling, we can refine it further at a later point. The main idea is to give the end user enough information to debug / fix the issue themselves.