### PR TITLE
fix: latest change in ProcessManager, change args passing

### DIFF
--- a/src/DataDefinitionsBundle/ProcessManager/ExportDefinitionProcess.php
+++ b/src/DataDefinitionsBundle/ProcessManager/ExportDefinitionProcess.php
@@ -31,8 +31,13 @@ final class ExportDefinitionProcess extends Pimcore
             $settings['params'] = (array)$params;
         }
 
-        $settings['command'] = sprintf('data-definitions:export -d %s -p "%s"', $settings['definition'],
-            addslashes(json_encode($settings['params'])));
+        $settings['command'] = [
+            'data-definitions:export',
+            '-d',
+            $settings['definition'],
+            '-p',
+            json_encode($settings['params']),
+        ];
 
         $executable->setSettings($settings);
 

--- a/src/DataDefinitionsBundle/ProcessManager/ImportDefinitionProcess.php
+++ b/src/DataDefinitionsBundle/ProcessManager/ImportDefinitionProcess.php
@@ -31,8 +31,13 @@ final class ImportDefinitionProcess extends Pimcore
             $params['userId'] = $currentUser->getId();
         }
 
-        $settings['command'] = sprintf('data-definitions:import -d %s -p "%s"', $settings['definition'],
-            addslashes(json_encode($params)));
+        $settings['command'] = [
+            'data-definitions:import',
+            '-d',
+            $settings['definition'],
+            '-p',
+            json_encode($params),
+        ];
 
         $executable->setSettings($settings);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | https://github.com/dpfaffenbauer/ProcessManager/pull/59

Correctly passes the arguments with the BC break in Pimcore.