### PR TITLE
Fix/empty array and wrong entity manager

### DIFF
--- a/src/DataDefinitionsBundle/Command/AbstractImportDefinitionCommand.php
+++ b/src/DataDefinitionsBundle/Command/AbstractImportDefinitionCommand.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Wvision\Bundle\DataDefinitionsBundle\Command;
 
 use CoreShop\Bundle\ResourceBundle\Controller\ResourceFormFactoryInterface;
+use CoreShop\Bundle\ResourceBundle\Pimcore\ObjectManager;
 use CoreShop\Component\Resource\Metadata\MetadataInterface;
 use CoreShop\Component\Resource\Repository\RepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
@@ -31,13 +32,13 @@ abstract class AbstractImportDefinitionCommand extends AbstractCommand
 {
     protected MetadataInterface $metadata;
     protected DefinitionRepository $repository;
-    protected EntityManagerInterface $manager;
+    protected ObjectManager $manager;
     protected ResourceFormFactoryInterface $resourceFormFactory;
 
     public function __construct(
         MetadataInterface $metadata,
         DefinitionRepository $repository,
-        EntityManagerInterface $manager,
+        ObjectManager $manager,
         ResourceFormFactoryInterface $resourceFormFactory
     ) {
         $this->metadata = $metadata;

--- a/src/DataDefinitionsBundle/Model/ImportDefinition/Dao.php
+++ b/src/DataDefinitionsBundle/Model/ImportDefinition/Dao.php
@@ -102,7 +102,7 @@ class Dao extends Model\Dao\PhpArrayTable
             return $row['name'] === $name;
         });
 
-        if ($data[0]['id'] && count($data)) {
+        if (isset($data[0]['id']) && count($data)) {
             $this->assignVariablesToModel($data[0]);
         } else {
             throw new InvalidArgumentException(sprintf('Definition with name: %s does not exist',

--- a/src/DataDefinitionsBundle/Resources/config/services/commands.yml
+++ b/src/DataDefinitionsBundle/Resources/config/services/commands.yml
@@ -31,7 +31,7 @@ services:
         arguments:
             - '@=service("CoreShop\\Component\\Resource\\Metadata\\RegistryInterface").get("data_definitions.import_definition")'
             - '@data_definitions.repository.import_definition'
-            - '@doctrine.orm.default_entity_manager'
+            - '@CoreShop\Bundle\ResourceBundle\Pimcore\ObjectManager'
             - '@CoreShop\Bundle\ResourceBundle\Controller\ResourceFormFactoryInterface'
         tags:
             - { name: 'console.command', command: 'data-definitions:definition:import:import' }
@@ -40,7 +40,7 @@ services:
         arguments:
             - '@=service("CoreShop\\Component\\Resource\\Metadata\\RegistryInterface").get("data_definitions.export_definition")'
             - '@data_definitions.repository.export_definition'
-            - '@doctrine.orm.default_entity_manager'
+            - '@CoreShop\Bundle\ResourceBundle\Pimcore\ObjectManager'
             - '@CoreShop\Bundle\ResourceBundle\Controller\ResourceFormFactoryInterface'
         tags:
             - { name: 'console.command', command: 'data-definitions:definition:import:export' }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

1. Fix importing new import/exportDefinition:
- importing command expects `InvalidArgumentException` when no definition exists in system
- WAS: error wash thrown 
- IS: correct exception is thrown

2. Fix wrong entity model in import commands:
- `@doctrine.orm.default_entity_manager` can't handle Definition entity
