### PR TITLE
Event "data_definitions.import.total" never gets dispatched

### DIFF
--- a/src/DataDefinitionsBundle/Importer/Importer.php
+++ b/src/DataDefinitionsBundle/Importer/Importer.php
@@ -111,8 +111,8 @@ final class Importer implements ImporterInterface
         /** @var ImportDataSetInterface|array $data */
         $data = $this->getData($definition, $params);
 
-        if ((\is_countable($data) || $data instanceof Countable) && \count($data) > 0) {
-            $this->eventDispatcher->dispatch($definition, 'data_definitions.import.total', \count($data), $params);
+        if ((\is_countable($data) || $data instanceof Countable) && $data->count() > 0) {
+            $this->eventDispatcher->dispatch($definition, 'data_definitions.import.total', $data->count(), $params);
         }
 
         [$objectIds, $exceptions] = $this->runImport($definition, $params, $filter, $data);

--- a/src/DataDefinitionsBundle/Importer/Importer.php
+++ b/src/DataDefinitionsBundle/Importer/Importer.php
@@ -111,8 +111,8 @@ final class Importer implements ImporterInterface
         /** @var ImportDataSetInterface|array $data */
         $data = $this->getData($definition, $params);
 
-        if ((\is_countable($data) || $data instanceof Countable) && $data->count() > 0) {
-            $this->eventDispatcher->dispatch($definition, 'data_definitions.import.total', $data->count(), $params);
+        if ((\is_countable($data) || $data instanceof Countable) && \count($data) > 0) {
+            $this->eventDispatcher->dispatch($definition, 'data_definitions.import.total', \count($data), $params);
         }
 
         [$objectIds, $exceptions] = $this->runImport($definition, $params, $filter, $data);

--- a/src/DataDefinitionsBundle/Provider/TraversableImportDataSet.php
+++ b/src/DataDefinitionsBundle/Provider/TraversableImportDataSet.php
@@ -28,8 +28,8 @@ class TraversableImportDataSet implements ImportDataSetInterface, Countable
 
     public function __construct(Traversable $iterator)
     {
+        $this->count = iterator_count($iterator);
         $this->iterator = new IteratorIterator($iterator);
-        $this->count = iterator_count($this->iterator);
     }
 
     /**

--- a/src/DataDefinitionsBundle/Provider/TraversableImportDataSet.php
+++ b/src/DataDefinitionsBundle/Provider/TraversableImportDataSet.php
@@ -9,23 +9,27 @@
  * files that are distributed with this source code.
  *
  * @copyright  Copyright (c) 2016-2019 w-vision AG (https://www.w-vision.ch)
- * @license    https://github.com/w-vision/DataDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ * @license    https://github.com/w-vision/DataDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3
+ *     (GPLv3)
  */
 
 declare(strict_types=1);
 
 namespace Wvision\Bundle\DataDefinitionsBundle\Provider;
 
-use Closure;
-use Iterator;
+use Countable;
+use IteratorIterator;
+use Traversable;
 
-class TraversableImportDataSet implements ImportDataSetInterface
+class TraversableImportDataSet implements ImportDataSetInterface, Countable
 {
-    private \IteratorIterator $iterator;
+    private IteratorIterator $iterator;
+    private int $count;
 
-    public function __construct(\Traversable $iterator)
+    public function __construct(Traversable $iterator)
     {
-        $this->iterator = new \IteratorIterator($iterator);
+        $this->iterator = new IteratorIterator($iterator);
+        $this->count = iterator_count($this->iterator);
     }
 
     /**
@@ -82,5 +86,14 @@ class TraversableImportDataSet implements ImportDataSetInterface
     public function rewind()
     {
         $this->iterator->rewind();
+    }
+
+    /**
+     * Return the number of elements in the Iterator
+     * @return int
+     */
+    public function count(): int
+    {
+        return $this->count;
     }
 }

--- a/src/DataDefinitionsBundle/Provider/TraversableImportDataSet.php
+++ b/src/DataDefinitionsBundle/Provider/TraversableImportDataSet.php
@@ -9,27 +9,22 @@
  * files that are distributed with this source code.
  *
  * @copyright  Copyright (c) 2016-2019 w-vision AG (https://www.w-vision.ch)
- * @license    https://github.com/w-vision/DataDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3
- *     (GPLv3)
+ * @license    https://github.com/w-vision/DataDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
  */
 
 declare(strict_types=1);
 
 namespace Wvision\Bundle\DataDefinitionsBundle\Provider;
 
-use Countable;
-use IteratorIterator;
-use Traversable;
-
-class TraversableImportDataSet implements ImportDataSetInterface, Countable
+class TraversableImportDataSet implements ImportDataSetInterface, \Countable
 {
-    private IteratorIterator $iterator;
+    private \IteratorIterator $iterator;
     private int $count;
 
-    public function __construct(Traversable $iterator)
+    public function __construct(\Traversable $iterator)
     {
         $this->count = iterator_count($iterator);
-        $this->iterator = new IteratorIterator($iterator);
+        $this->iterator = new \IteratorIterator($iterator);
     }
 
     /**


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug report?      | yes
| Feature request? | no
| BC Break report? | no
| RFC?             | yes
| Branch?          | master

In Importer.php the event "data_definitions.import.total" never gets get dispatched when $data is an object of type \Wvision\Bundle\DataDefinitionsBundle\Provider\TraversableImportDataSet.

Fixed this by adding Countable interface and setting the count on object creation.
