### PR TITLE
Checks if parameters are set because of strict_types directive

### DIFF
--- a/src/DataDefinitionsBundle/Fetcher/ObjectsFetcher.php
+++ b/src/DataDefinitionsBundle/Fetcher/ObjectsFetcher.php
@@ -61,21 +61,21 @@ class ObjectsFetcher implements FetcherInterface
             }
         }
 
-        if ($params['query']) {
+        if (isset($params['query'])) {
             $query = $this->filterQueryParam($params['query']);
             if (!empty($query)) {
                 $conditionFilters[] = 'oo_id IN (SELECT id FROM search_backend_data WHERE MATCH (`data`,`properties`) AGAINST (' . $list->quote($query) . ' IN BOOLEAN MODE))';
             }
         }
 
-        if ($params['only_direct_children'] == 'true' && null !== $rootNode) {
+        if (isset($params['only_direct_children']) && $params['only_direct_children'] == 'true' && null !== $rootNode) {
             $conditionFilters[] = 'o_parentId = ' . $rootNode->getId();
         }
 
-        if ($params['condition']) {
+        if (isset($params['condition'])) {
             $conditionFilters[] = '(' . $params['condition'] . ')';
         }
-        if ($params['ids']) {
+        if (isset($params['ids'])) {
             $quotedIds = [];
             foreach ($params['ids'] as $id) {
                 $quotedIds[] = $list->quote($id);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | n/a

In the current 4.0 state its not possible to export any definition because of the strict_types directive in the ObjectsFetcher.php class. Since the behavior changed, a simple `if($params['something'])` query will result in an error message. Only workaround is to set all parameters that are queried until this is fixed.

This change proposes to check if parameters are actually available through `isset`, as it is done already with `root`