### PR TITLE
fix: properly account for progress steps when throttling status

### DIFF
--- a/src/DataDefinitionsBundle/ProcessManager/ProcessManagerExportListener.php
+++ b/src/DataDefinitionsBundle/ProcessManager/ProcessManagerExportListener.php
@@ -42,6 +42,7 @@ final class ProcessManagerExportListener extends AbstractProcessManagerListener
     {
         if (null !== $this->process) {
             if ($this->process->getStatus() == ProcessManagerBundle::STATUS_RUNNING) {
+                $this->process->setProgress($this->process->getTotal());
                 $this->process->setStatus(ProcessManagerBundle::STATUS_COMPLETED);
                 $this->process->save();
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #331

We introduced a tweak which stops the status event being dispatched too often, but this has two side-effects with the progress bar in Process manager:
1. it doesn't update correctly
2. it never reaches 100%

This fixes both issues.