### PR TITLE
fix: XML Provider export rename() not friendly to streams

### DIFF
--- a/src/DataDefinitionsBundle/Provider/XmlProvider.php
+++ b/src/DataDefinitionsBundle/Provider/XmlProvider.php
@@ -156,7 +156,8 @@ class XmlProvider extends AbstractFileProvider implements ImportProviderInterfac
         }
 
         $file = $this->getFile($params);
-        rename($this->getExportPath(), $file);
+        copy($this->getExportPath(), $file);
+        unlink($this->getExportPath());
     }
 
     public function provideArtifactStream($configuration, ExportDefinitionInterface $definition, $params)


### PR DESCRIPTION
Using copy() + unlink() instead

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

