### PR TITLE
fix: display exception in process manager logs

### DIFF
--- a/src/DataDefinitionsBundle/Importer/Importer.php
+++ b/src/DataDefinitionsBundle/Importer/Importer.php
@@ -257,19 +257,6 @@ final class Importer implements ImporterInterface
                 if ($object instanceof Concrete) {
                     $objectIds[] = $object->getId();
                 }
-
-                if (($count + 1) % $countToClean === 0) {
-                    Pimcore::collectGarbage();
-                    $this->logger->info('Clean Garbage');
-                    $this->eventDispatcher->dispatch(
-                        $definition,
-                        'data_definitions.import.status',
-                        'Collect Garbage',
-                        $params
-                    );
-                }
-
-                $count++;
             } catch (Throwable $ex) {
                 $this->logger->error($ex);
 
@@ -285,6 +272,19 @@ final class Importer implements ImporterInterface
                 if ($definition->getStopOnException()) {
                     throw $ex;
                 }
+            } finally {
+                if (($count + 1) % $countToClean === 0) {
+                    Pimcore::collectGarbage();
+                    $this->logger->info('Clean Garbage');
+                    $this->eventDispatcher->dispatch(
+                        $definition,
+                        'data_definitions.import.status',
+                        'Collect Garbage',
+                        $params
+                    );
+                }
+
+                $count++;
             }
 
             $this->eventDispatcher->dispatch($definition, 'data_definitions.import.progress', '', $params);

--- a/src/DataDefinitionsBundle/Importer/Importer.php
+++ b/src/DataDefinitionsBundle/Importer/Importer.php
@@ -277,7 +277,7 @@ final class Importer implements ImporterInterface
 
                 $this->eventDispatcher->dispatch(
                     $definition,
-                    'data_definitions.import.status',
+                    'data_definitions.import.failure',
                     sprintf('Error: %s', $ex->getMessage()),
                     $params
                 );

--- a/src/DataDefinitionsBundle/ProcessManager/AbstractProcessManagerListener.php
+++ b/src/DataDefinitionsBundle/ProcessManager/AbstractProcessManagerListener.php
@@ -195,6 +195,10 @@ abstract class AbstractProcessManagerListener
             }
             $this->process->setCompleted(time());
             $this->process->save();
+
+            if (is_string($event->getSubject())) {
+                $this->processLogger->info($this->process, ImportDefinitionsReport::EVENT_STATUS_ERROR.$event->getSubject());
+            }
         }
     }
 }

--- a/src/DataDefinitionsBundle/ProcessManager/AbstractProcessManagerListener.php
+++ b/src/DataDefinitionsBundle/ProcessManager/AbstractProcessManagerListener.php
@@ -145,6 +145,8 @@ abstract class AbstractProcessManagerListener
     public function onStatusEvent(DefinitionEventInterface $event): void
     {
         if ($this->process) {
+            $this->processLogger->info($this->process, ImportDefinitionsReport::EVENT_STATUS.$event->getSubject());
+
             $now = new \DateTimeImmutable();
             if ($this->lastStatusAt instanceof \DateTimeInterface) {
                 $diff = $now->getTimestamp() - $this->lastStatusAt->getTimestamp();
@@ -160,8 +162,6 @@ abstract class AbstractProcessManagerListener
             }
             $this->process->setMessage($event->getSubject());
             $this->process->save();
-
-            $this->processLogger->info($this->process, ImportDefinitionsReport::EVENT_STATUS.$event->getSubject());
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

Exceptions will not show up in Process Manager logs because we've throttled the status updates for performance reasons. Exceptions should be exempt.