### PR TITLE
feat: deduplicate assets by hash

### DIFF
--- a/src/DataDefinitionsBundle/Form/Type/Interpreter/AssetUrlInterpreterType.php
+++ b/src/DataDefinitionsBundle/Form/Type/Interpreter/AssetUrlInterpreterType.php
@@ -28,6 +28,8 @@ final class AssetUrlInterpreterType extends AbstractType
         $builder
             ->add('path', TextType::class)
             ->add('deduplicate_by_url', CheckboxType::class)
+            ->add('deduplicate_by_hash', CheckboxType::class)
+            ->add('use_content_disposition', CheckboxType::class)
             ->add('relocate_existing_objects', CheckboxType::class)
             ->add('rename_existing_objects', CheckboxType::class);
     }

--- a/src/DataDefinitionsBundle/Form/Type/Interpreter/AssetsUrlInterpreterType.php
+++ b/src/DataDefinitionsBundle/Form/Type/Interpreter/AssetsUrlInterpreterType.php
@@ -28,6 +28,8 @@ final class AssetsUrlInterpreterType extends AbstractType
         $builder
             ->add('path', TextType::class)
             ->add('deduplicate_by_url', CheckboxType::class)
+            ->add('deduplicate_by_hash', CheckboxType::class)
+            ->add('use_content_disposition', CheckboxType::class)
             ->add('relocate_existing_objects', CheckboxType::class)
             ->add('rename_existing_objects', CheckboxType::class);
     }

--- a/src/DataDefinitionsBundle/Interpreter/AssetUrlInterpreter.php
+++ b/src/DataDefinitionsBundle/Interpreter/AssetUrlInterpreter.php
@@ -24,6 +24,7 @@ use Wvision\Bundle\DataDefinitionsBundle\Context\InterpreterContextInterface;
 class AssetUrlInterpreter implements InterpreterInterface
 {
     protected const METADATA_ORIGIN_URL = 'origin_url';
+    protected const METADATA_ORIGIN_HASH = 'origin_hash';
     protected \Psr\Http\Client\ClientInterface $httpClient;
     protected \Psr\Http\Message\RequestFactoryInterface $requestFactory;
 
@@ -38,105 +39,122 @@ class AssetUrlInterpreter implements InterpreterInterface
     public function interpret(InterpreterContextInterface $context): mixed
     {
         $path = $context->getConfiguration()['path'];
+        $url = $context->getValue();
 
-        if (filter_var($context->getValue(), FILTER_VALIDATE_URL)) {
-            $asset = null;
-            $filename = $this->getFileName($context->getValue());
-
-            if ($context->getConfiguration()['deduplicate_by_url']) {
-                if ($asset = $this->getDuplicatedAsset($context->getValue())) {
-                    $filename = $asset->getFilename();
-                    $assetPath = $asset->getPath();
-                } else {
-                    $assetPath = $path;
-                }
-            } else {
-                $assetPath = $path;
-            }
-
-            $parent = Asset\Service::createFolderByPath($assetPath);
-
-            if (!$asset instanceof Asset) {
-                // Download
-                $fileData = $this->getFileContents($context->getValue());
-
-                if ($fileData) {
-                    $asset = Asset::create($parent->getId(), [
-                        'filename' => $filename,
-                        'data' => $fileData,
-                    ], false);
-                    $asset->addMetadata(self::METADATA_ORIGIN_URL, 'input', $context->getValue());
-                    $asset->save();
-                }
-            } else {
-                $save = false;
-
-                if ($context->getConfiguration()['relocate_existing_objects'] && $asset->getParent() !== $parent) {
-                    $asset->setParent($parent);
-                    $save = true;
-                }
-
-                if ($context->getConfiguration()['rename_existing_objects'] && $asset->getFilename() !== $filename) {
-                    $asset->setFilename($filename);
-                    $save = true;
-                }
-
-                if ($save) {
-                    $asset->save();
-                }
-            }
-
-            return $asset;
+        if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+            throw new \InvalidArgumentException(sprintf('Provided asset URL value %1$s is not a valid URL', $url));
         }
 
-        return null;
+        $asset = null;
+        if ($context->getConfiguration()['deduplicate_by_url']) {
+            $asset = $this->deduplicateAssetByUrl($url);
+        }
+
+        $fileHash = null;
+        if ($asset === null) {
+            $fileData = $this->getFileContents($url);
+            $fileHash = md5($fileData);
+
+            if ($context->getConfiguration()['deduplicate_by_hash']) {
+                $asset = $this->deduplicateAssetByHash($fileHash);
+            }
+        }
+
+        if ($asset === null) {
+            // asset doesn't exist already
+            $parent = Asset\Service::createFolderByPath($path);
+            $filename = $this->getFileName($url);
+            $asset = Asset::create($parent->getId(), [
+                'filename' => $filename,
+                'data' => $fileData,
+            ], false);
+        }
+
+        $save = false;
+        $currentUrl = $asset->getMetadata(self::METADATA_ORIGIN_URL) ?? '';
+        if (strpos($currentUrl, $url) === false) {
+            $url = $currentUrl ? $currentUrl .'|'. $url : $url;
+            $asset->addMetadata(self::METADATA_ORIGIN_URL, 'input', $url);
+            $save = true;
+        }
+
+        // $fileHash might not be available here if we deduplicated by URL
+        if ($fileHash !== null && $asset->getMetadata(self::METADATA_ORIGIN_HASH) !== $fileHash) {
+            $asset->addMetadata(self::METADATA_ORIGIN_HASH, 'input', $fileHash);
+            $save = true;
+        }
+        if ($context->getConfiguration()['relocate_existing_objects'] && $asset->getParent() !== $parent) {
+            $asset->setParent($parent);
+            $save = true;
+        }
+        if ($context->getConfiguration()['rename_existing_objects'] && $asset->getFilename() !== $filename) {
+            $asset->setFilename($filename);
+            $save = true;
+        }
+
+        if ($save) {
+            $asset->save();
+        }
+
+        return $asset;
     }
 
-    private function getFileName(string $url): ?string
+    private function getFileName(string $url, bool $useContentDisposition = false): ?string
     {
         $filename = null;
-        try {
-            $request = $this->requestFactory->createRequest('HEAD', $url);
-            $response = $this->httpClient->sendRequest($request);
-            $headers = $response->getHeaders();
+        if ($useContentDisposition) {
+            try {
+                $request = $this->requestFactory->createRequest('HEAD', $url);
+                $response = $this->httpClient->sendRequest($request);
+                $headers = $response->getHeaders();
 
-            if (
-                isset($headers["Content-Disposition"]) &&
-                preg_match(
-                    '/^.*?filename=(?<f>[^\s]+|\x22[^\x22]+\x22)\x3B?.*$/m',
-                    current($headers["Content-Disposition"]),
-                    $match
-                )
-            ) {
-                $filename = trim($match['f'], ' ";');
+                if (
+                    isset($headers["Content-Disposition"]) &&
+                    preg_match(
+                        '/^.*?filename=(?<f>[^\s]+|\x22[^\x22]+\x22)\x3B?.*$/m',
+                        current($headers["Content-Disposition"]),
+                        $match
+                    )
+                ) {
+                    $filename = trim($match['f'], ' ";');
+                }
+            } catch (\Psr\Http\Client\ClientExceptionInterface $exception) {
             }
-        } catch (\Psr\Http\Client\ClientExceptionInterface $exception) {
+        }
+        if ($filename === null) {
+            $filename = basename($url);
         }
 
-        if (!$filename) {
-            $filename = File::getValidFilename(basename($url));
-        }
-
-        return $filename;
+        return File::getValidFilename($filename);
     }
 
-    protected function getFileContents(string $value): ?string
+    protected function getFileContents(string $value): string
     {
         try {
             $request = $this->requestFactory->createRequest('GET', $value);
             $response = $this->httpClient->sendRequest($request);
         } catch (\Psr\Http\Client\ClientExceptionInterface $ex) {
-            return null;
+            throw new \RuntimeException('Unable to download asset from URL '.$value);
         }
 
         if ($response->getStatusCode() === 200) {
             return (string)$response->getBody();
         }
 
-        return null;
+        throw new \RuntimeException('Unable to download asset from URL '.$value);
     }
 
-    private function getDuplicatedAsset(string $value): ?Asset
+    private function deduplicateAssetByUrl(string $value): ?Asset
+    {
+        return $this->deduplicateAsset(self::METADATA_ORIGIN_URL, $value, true);
+    }
+
+    private function deduplicateAssetByHash(string $value): ?Asset
+    {
+        return $this->deduplicateAsset(self::METADATA_ORIGIN_HASH, $value);
+    }
+
+    private function deduplicateAsset(string $name, string $value, bool $fuzzy = false)
     {
         $listing = new Asset\Listing();
         $listing->onCreateQueryBuilder(
@@ -144,8 +162,12 @@ class AssetUrlInterpreter implements InterpreterInterface
                 $select->join('assets', 'assets_metadata', 'am', 'id = am.cid');
             }
         );
-        $listing->addConditionParam('am.name = ?', static::METADATA_ORIGIN_URL);
-        $listing->addConditionParam('am.data = ?', $value);
+        $listing->addConditionParam('am.name = ?', $name);
+        if ($fuzzy) {
+            $listing->addConditionParam('am.data LIKE ?', '%'. $value .'%');
+        } else {
+            $listing->addConditionParam('am.data = ?', $value);
+        }
         $listing->setLimit(1);
         $listing->setOrder(['creationDate', 'desc']);
 

--- a/src/DataDefinitionsBundle/Resources/public/pimcore/js/interpreters/asseturl.js
+++ b/src/DataDefinitionsBundle/Resources/public/pimcore/js/interpreters/asseturl.js
@@ -16,12 +16,13 @@ pimcore.registerNS('pimcore.plugin.datadefinitions.interpreters.asset_url');
 pimcore.plugin.datadefinitions.interpreters.asset_url = Class.create(pimcore.plugin.datadefinitions.interpreters.abstract, {
     getLayout: function (fromColumn, toColumn, record, config) {
         var deduplicateByUrlEnabled = Ext.isDefined(config.deduplicate_by_url) ? config.deduplicate_by_url : false
+        var deduplicateByHashEnabled = Ext.isDefined(config.deduplicate_by_hash) ? config.deduplicate_by_hash : false
         var relocateExistingCheckbox = Ext.create({
             xtype: 'checkbox',
             fieldLabel: t('data_definitions_relocate_existing_objects'),
             name: 'relocate_existing_objects',
             value: config.deduplicate_by_url && Ext.isDefined(config.relocate_existing_objects) ? config.relocate_existing_objects : false,
-            disabled: deduplicateByUrlEnabled === false
+            disabled: deduplicateByUrlEnabled === false || deduplicateByHashEnabled === false
         });
 
         var renameExistingCheckbox = Ext.create({
@@ -29,7 +30,7 @@ pimcore.plugin.datadefinitions.interpreters.asset_url = Class.create(pimcore.plu
             fieldLabel: t('data_definitions_rename_existing_objects'),
             name: 'rename_existing_objects',
             value: config.deduplicate_by_url && Ext.isDefined(config.rename_existing_objects) ? config.rename_existing_objects : false,
-            disabled: deduplicateByUrlEnabled === false
+            disabled: deduplicateByUrlEnabled === false || deduplicateByHashEnabled === false
         });
 
         return [{
@@ -95,6 +96,31 @@ pimcore.plugin.datadefinitions.interpreters.asset_url = Class.create(pimcore.plu
                             .setDisabled(isDeduplicateByUrlDisabled);
                     }
                 }
+            },
+            {
+                xtype: 'checkbox',
+                fieldLabel: t('data_definitions_interpreter_asset_url_deduplicate_by_hash'),
+                name: 'deduplicate_by_hash',
+                value: deduplicateByHashEnabled,
+                listeners: {
+                    change: function (el, enabled) {
+                        var isDeduplicateByHashDisabled = (enabled === false);
+
+                        relocateExistingCheckbox
+                            .setValue(false)
+                            .setDisabled(isDeduplicateByHashDisabled);
+
+                        renameExistingCheckbox
+                            .setValue(false)
+                            .setDisabled(isDeduplicateByHashDisabled);
+                    }
+                }
+            },
+            {
+                xtype: 'checkbox',
+                fieldLabel: t('data_definitions_interpreter_asset_url_use_content_disposition'),
+                name: 'use_content_disposition',
+                value: Ext.isDefined(config.use_content_disposition) ? config.use_content_disposition : false
             },
             relocateExistingCheckbox,
             renameExistingCheckbox


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | #349, #323

This revamps the Asset URL interpreter:
1. it no longer does a HEAD request each time just to get the filename by default, you need to opt-in to that (BC break), #349
2. it allows deduplicating assets by their MD5 checksum, not just the URL (for example, have a single asset importing from multiple URLs, it gets reused because the checksums match AND the second URL is added to the URLs we check against, it will be deduped by URL next time