### PR TITLE
fix: excel provider export rename() not friendly to streams

### DIFF
--- a/src/DataDefinitionsBundle/Provider/ExcelProvider.php
+++ b/src/DataDefinitionsBundle/Provider/ExcelProvider.php
@@ -141,7 +141,8 @@ class ExcelProvider extends AbstractFileProvider implements ImportProviderInterf
         }
 
         $file = $this->getFile($params);
-        rename($this->getExportPath(), $file);
+        copy($this->getExportPath(), $file);
+        unlink($this->getExportPath());
     }
 
     public function provideArtifactStream($configuration, ExportDefinitionInterface $definition, $params)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

This is the same fix as #357 just for ExcelProvider this time