### PR TITLE
fix: ClassificationStoreSetter doesn't handle empty groups correctly

### DIFF
--- a/src/DataDefinitionsBundle/Setter/ClassificationStoreSetter.php
+++ b/src/DataDefinitionsBundle/Setter/ClassificationStoreSetter.php
@@ -38,7 +38,7 @@ class ClassificationStoreSetter implements SetterInterface, GetterInterface
             if ($classificationStore instanceof Classificationstore) {
                 $groups = $classificationStore->getActiveGroups();
 
-                if (!$groups[$groupConfig]) {
+                if (!($groups[$groupConfig] ?? false)) {
                     $groups[$groupConfig] = true;
                     $classificationStore->setActiveGroups($groups);
                 }
@@ -63,7 +63,7 @@ class ClassificationStoreSetter implements SetterInterface, GetterInterface
             if ($classificationStore instanceof Classificationstore) {
                 $groups = $classificationStore->getActiveGroups();
 
-                if (!$groups[$groupConfig]) {
+                if (!($groups[$groupConfig] ?? false)) {
                     $groups[$groupConfig] = true;
                     $classificationStore->setActiveGroups($groups);
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes/no
| Fixed tickets | N(A

