### PR TITLE
Import by ID

### DIFF
--- a/src/DataDefinitionsBundle/Service/FieldSelection.php
+++ b/src/DataDefinitionsBundle/Service/FieldSelection.php
@@ -27,6 +27,7 @@ class FieldSelection
         $fields = $class->getFieldDefinitions();
 
         $systemColumns = [
+            'o_id',
             'o_published',
             'o_key',
             'o_parentId',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | https://github.com/w-vision/DataDefinitions/issues/256

### Use case
1. Export existing objects
2. Change some data
3. Import modified content back into the system using ID (`o_id`) as primary key
  

### Changes
1. `o_id` field is included in the map, `systemColumn` list
    - field can be used as primary key

---
![image](https://github.com/w-vision/DataDefinitions/assets/79514353/77ae13a6-86e5-4585-ae03-1c5a6ce626b4)
**Change includes `o_id` in the map, `systemColumn` list**
