### PR TITLE
Disable value trimming for default_value interpreter

### DIFF
--- a/src/DataDefinitionsBundle/Form/Type/Interpreter/DefaultValueInterpreterType.php
+++ b/src/DataDefinitionsBundle/Form/Type/Interpreter/DefaultValueInterpreterType.php
@@ -25,6 +25,6 @@ final class DefaultValueInterpreterType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('value', TextType::class);
+            ->add('value', TextType::class, ['trim' => false]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

In our project, we wanted to import single space strings using `default_value` interpreter. To our surprise, we couldn't, as Symfony trims the value by default.

In my opinion, the interpreter should not modify the value, ever. It's up to user to validate it.
