### PR TITLE
Fix export definition issues: enableInheritance field and invalid callback for getSuggestedId()

### DIFF
--- a/src/DataDefinitionsBundle/DependencyInjection/Configuration.php
+++ b/src/DataDefinitionsBundle/DependencyInjection/Configuration.php
@@ -110,6 +110,7 @@ class Configuration implements ConfigurationInterface
                             ->variableNode('configuration')->end()
                             ->scalarNode('runner')->end()
                             ->booleanNode('stopOnException')->end()
+                            ->booleanNode('enableInheritance')->end()
                             ->scalarNode('failureNotificationDocument')->end()
                             ->scalarNode('successNotificationDocument')->end()
                             ->arrayNode('mapping')

--- a/src/DataDefinitionsBundle/Model/IdGenerator.php
+++ b/src/DataDefinitionsBundle/Model/IdGenerator.php
@@ -9,7 +9,7 @@ trait IdGenerator
 {
     private string $mainPath = 'var/config';
 
-    private function getSuggestedId(ExportListing|ImportListing $listing): int
+    public function getSuggestedId(ExportListing|ImportListing $listing): int
     {
         $ids = $listing->getAllIds();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes

<!--
- Fix issue with enableInheritance field not being recognized in export definition
- Fix invalid callback error by making ExportDefinition::getSuggestedId() public
-->
