### PR TITLE
Configuration of ImportDefinition is returned when getting ExportDefinition by ID

### DIFF
--- a/src/DataDefinitionsBundle/Model/ExportDefinition/Dao.php
+++ b/src/DataDefinitionsBundle/Model/ExportDefinition/Dao.php
@@ -39,7 +39,7 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
 
         parent::configure([
             'containerConfig' => $definitions,
-            'settingsStoreScope' => 'data_definitions',
+            'settingsStoreScope' => 'data_definitions.' . self::CONFIG_KEY,
             'storageConfig' => $storageConfig,
         ]);
     }

--- a/src/DataDefinitionsBundle/Model/ExportDefinition/Dao.php
+++ b/src/DataDefinitionsBundle/Model/ExportDefinition/Dao.php
@@ -40,7 +40,7 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
 
         parent::configure([
             'containerConfig' => $definitions,
-            'settingsStoreScope' => 'data_definitions',
+            'settingsStoreScope' => 'data_definitions.' . self::CONFIG_KEY,
             'storageConfig' => $storageConfig,
         ]);
     }

--- a/src/DataDefinitionsBundle/Model/ExportDefinition/Dao.php
+++ b/src/DataDefinitionsBundle/Model/ExportDefinition/Dao.php
@@ -39,7 +39,7 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
 
         parent::configure([
             'containerConfig' => $definitions,
-            'settingsStoreScope' => 'data_definitions.' . self::CONFIG_KEY,
+            'settingsStoreScope' => 'data_definitions',
             'storageConfig' => $storageConfig,
         ]);
     }

--- a/src/DataDefinitionsBundle/Model/ImportDefinition/Dao.php
+++ b/src/DataDefinitionsBundle/Model/ImportDefinition/Dao.php
@@ -42,7 +42,7 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
 
         parent::configure([
             'containerConfig' => $definitions,
-            'settingsStoreScope' => 'data_definitions',
+            'settingsStoreScope' => 'data_definitions.' . self::CONFIG_KEY,
             'storageConfig' => $storageConfig,
         ]);
     }

--- a/src/DataDefinitionsBundle/Model/ImportDefinition/Dao.php
+++ b/src/DataDefinitionsBundle/Model/ImportDefinition/Dao.php
@@ -42,7 +42,7 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
 
         parent::configure([
             'containerConfig' => $definitions,
-            'settingsStoreScope' => 'data_definitions.' . self::CONFIG_KEY,
+            'settingsStoreScope' => 'data_definitions',
             'storageConfig' => $storageConfig,
         ]);
     }

--- a/src/DataDefinitionsBundle/Model/ImportDefinition/Dao.php
+++ b/src/DataDefinitionsBundle/Model/ImportDefinition/Dao.php
@@ -43,7 +43,7 @@ class Dao extends Model\Dao\PimcoreLocationAwareConfigDao
 
         parent::configure([
             'containerConfig' => $definitions,
-            'settingsStoreScope' => 'data_definitions',
+            'settingsStoreScope' => 'data_definitions.' . self::CONFIG_KEY,
             'storageConfig' => $storageConfig,
         ]);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #424 

Correctly set a unique value for the `settingsStoreScope` key in Import- and ExportDefinition DAO's for PimcoreLocationAwareConfigDao to correctly load in the corresponding data.