### PR TITLE
Load Objectbrick class with first letter always uppercase

### DIFF
--- a/src/DataDefinitionsBundle/Setter/ObjectbrickSetter.php
+++ b/src/DataDefinitionsBundle/Setter/ObjectbrickSetter.php
@@ -50,7 +50,7 @@ class ObjectbrickSetter implements SetterInterface, GetterInterface
                 $brickFieldObject = $brick->$brickClassGetter();
 
                 if (!$brickFieldObject instanceof AbstractData) {
-                    $brickFieldObjectClass = 'Pimcore\Model\DataObject\Objectbrick\Data\\' . $class;
+                    $brickFieldObjectClass = 'Pimcore\Model\DataObject\Objectbrick\Data\\' . ucfirst($class);
 
                     $brickFieldObject = new $brickFieldObjectClass($context->getObject());
 
@@ -90,7 +90,7 @@ class ObjectbrickSetter implements SetterInterface, GetterInterface
             $brickFieldObject = $brick->$brickClassGetter();
 
             if (!$brickFieldObject instanceof AbstractData) {
-                $brickFieldObjectClass = 'Pimcore\Model\DataObject\Objectbrick\Data\\' . $class;
+                $brickFieldObjectClass = 'Pimcore\Model\DataObject\Objectbrick\Data\\' . ucfirst($class);
 
                 $brickFieldObject = new $brickFieldObjectClass($context->getObject());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no

Even if the name of an objectbrick is in lowercase, the generated class in var/classes/DataObject/Objectbrick/Data is always in uppercase. The ObjectBrickSetter now loads the class with the first letter in uppercase.