### PR TITLE
fix wrong parameter bool to array on Primarykeyloader, (getById)

### DIFF
--- a/src/DataDefinitionsBundle/Loader/PrimaryKeyLoader.php
+++ b/src/DataDefinitionsBundle/Loader/PrimaryKeyLoader.php
@@ -68,7 +68,7 @@ class PrimaryKeyLoader implements LoaderInterface
                 $obj = $objectData[0];
 
                 if ($context->getDefinition()->getForceLoadObject()) {
-                    $obj = DataObject::getById($obj->getId(), true);
+                    $obj = DataObject::getById($obj->getId(), ['force' => true]);
 
                     if (!$obj instanceof $classObject) {
                         $obj = new $classObject();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |


Corrected the primarykeyloader interpreter by using the expected parameter type (array instead of boolean) for getById Pimcore function.